### PR TITLE
refactor(runtime): decompose ExecutionContext into focused sub-types

### DIFF
--- a/cmd/invowk/cmd_validate_checks.go
+++ b/cmd/invowk/cmd_validate_checks.go
@@ -137,10 +137,9 @@ func validateCustomCheckInVirtual(check invkfile.CustomCheck, registry *runtime.
 		Invkfile:        ctx.Invkfile,
 		SelectedImpl:    &invkfile.Implementation{Script: check.CheckScript, Runtimes: []invkfile.RuntimeConfig{{Name: invkfile.RuntimeVirtual}}},
 		SelectedRuntime: invkfile.RuntimeVirtual,
-		Stdout:          &stdout,
-		Stderr:          &stderr,
 		Context:         ctx.Context,
-		ExtraEnv:        make(map[string]string),
+		IO:              runtime.IOContext{Stdout: &stdout, Stderr: &stderr},
+		Env:             runtime.DefaultEnv(),
 	}
 
 	result := rt.Execute(validationCtx)
@@ -163,10 +162,9 @@ func validateCustomCheckInContainer(check invkfile.CustomCheck, registry *runtim
 		Invkfile:        ctx.Invkfile,
 		SelectedImpl:    &invkfile.Implementation{Script: check.CheckScript, Runtimes: []invkfile.RuntimeConfig{{Name: invkfile.RuntimeContainer}}},
 		SelectedRuntime: invkfile.RuntimeContainer,
-		Stdout:          &stdout,
-		Stderr:          &stderr,
 		Context:         ctx.Context,
-		ExtraEnv:        make(map[string]string),
+		IO:              runtime.IOContext{Stdout: &stdout, Stderr: &stderr},
+		Env:             runtime.DefaultEnv(),
 	}
 
 	result := rt.Execute(validationCtx)

--- a/cmd/invowk/cmd_validate_filepaths.go
+++ b/cmd/invowk/cmd_validate_filepaths.go
@@ -90,10 +90,9 @@ func validateFilepathInContainer(fp invkfile.FilepathDependency, invowkDir strin
 			Invkfile:        ctx.Invkfile,
 			SelectedImpl:    &invkfile.Implementation{Script: checkScript, Runtimes: []invkfile.RuntimeConfig{{Name: invkfile.RuntimeContainer}}},
 			SelectedRuntime: invkfile.RuntimeContainer,
-			Stdout:          &stdout,
-			Stderr:          &stderr,
 			Context:         ctx.Context,
-			ExtraEnv:        make(map[string]string),
+			IO:              runtime.IOContext{Stdout: &stdout, Stderr: &stderr},
+			Env:             runtime.DefaultEnv(),
 		}
 
 		result := rt.Execute(validationCtx)

--- a/cmd/invowk/cmd_validate_tools.go
+++ b/cmd/invowk/cmd_validate_tools.go
@@ -93,10 +93,9 @@ func validateToolInVirtual(toolName string, registry *runtime.Registry, ctx *run
 		Invkfile:        ctx.Invkfile,
 		SelectedImpl:    &invkfile.Implementation{Script: checkScript, Runtimes: []invkfile.RuntimeConfig{{Name: invkfile.RuntimeVirtual}}},
 		SelectedRuntime: invkfile.RuntimeVirtual,
-		Stdout:          &stdout,
-		Stderr:          &stderr,
 		Context:         ctx.Context,
-		ExtraEnv:        make(map[string]string),
+		IO:              runtime.IOContext{Stdout: &stdout, Stderr: &stderr},
+		Env:             runtime.DefaultEnv(),
 	}
 
 	result := rt.Execute(validationCtx)
@@ -125,10 +124,9 @@ func validateToolInContainer(toolName string, registry *runtime.Registry, ctx *r
 		Invkfile:        ctx.Invkfile,
 		SelectedImpl:    &invkfile.Implementation{Script: checkScript, Runtimes: []invkfile.RuntimeConfig{{Name: invkfile.RuntimeContainer}}},
 		SelectedRuntime: invkfile.RuntimeContainer,
-		Stdout:          &stdout,
-		Stderr:          &stderr,
 		Context:         ctx.Context,
-		ExtraEnv:        make(map[string]string),
+		IO:              runtime.IOContext{Stdout: &stdout, Stderr: &stderr},
+		Env:             runtime.DefaultEnv(),
 	}
 
 	result := rt.Execute(validationCtx)

--- a/internal/runtime/container_exec.go
+++ b/internal/runtime/container_exec.go
@@ -178,10 +178,10 @@ func (r *ContainerRuntime) Execute(ctx *ExecutionContext) *Result {
 		Volumes:     prep.volumes,
 		Ports:       prep.ports,
 		Remove:      true, // Always remove after execution
-		Stdin:       ctx.Stdin,
-		Stdout:      ctx.Stdout,
-		Stderr:      ctx.Stderr,
-		Interactive: ctx.Stdin != nil,
+		Stdin:       ctx.IO.Stdin,
+		Stdout:      ctx.IO.Stdout,
+		Stderr:      ctx.IO.Stderr,
+		Interactive: ctx.IO.Stdin != nil,
 		ExtraHosts:  prep.extraHosts,
 	}
 

--- a/internal/runtime/container_integration_provision_test.go
+++ b/internal/runtime/container_integration_provision_test.go
@@ -49,8 +49,8 @@ func TestContainerRuntime_ProvisioningLayer_InvkfileAccess(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -102,8 +102,8 @@ echo "Script executed from /workspace"
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -158,8 +158,8 @@ func TestContainerRuntime_ProvisioningLayer_NestedDirectories(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -200,8 +200,8 @@ func TestContainerRuntime_ProvisioningLayer_WorkspaceIsCwd(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {

--- a/internal/runtime/container_integration_test.go
+++ b/internal/runtime/container_integration_test.go
@@ -68,8 +68,8 @@ func testContainerBasicExecution(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -114,8 +114,8 @@ func testContainerEnvironmentVariables(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -158,8 +158,8 @@ echo "Variable: $VAR"`
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -207,8 +207,8 @@ func testContainerWorkingDirectory(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -265,8 +265,8 @@ func testContainerVolumeMounts(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -304,8 +304,8 @@ func testContainerExitCode(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 42 {
@@ -336,8 +336,8 @@ func testContainerPositionalArgs(t *testing.T) {
 	execCtx.PositionalArgs = []string{"hello", "world"}
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {
@@ -381,8 +381,8 @@ func testContainerEnableHostSSHEnvVars(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 

--- a/internal/runtime/container_integration_validation_test.go
+++ b/internal/runtime/container_integration_validation_test.go
@@ -120,8 +120,8 @@ func TestContainerRuntime_EnableHostSSH_NoServer(t *testing.T) {
 	execCtx.Context = context.Background()
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 
@@ -173,8 +173,8 @@ RUN echo "Built from Containerfile" > /built.txt
 	execCtx.Verbose = true
 
 	var stdout, stderr bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &stderr
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &stderr
 
 	result := rt.Execute(execCtx)
 	if result.ExitCode != 0 {

--- a/internal/runtime/container_prepare.go
+++ b/internal/runtime/container_prepare.go
@@ -127,7 +127,7 @@ func (r *ContainerRuntime) PrepareCommand(ctx *ExecutionContext) (*PreparedComma
 
 	// Build extra hosts for accessing host services from container
 	var extraHosts []string
-	needsHostAccess := hostSSHEnabled || ctx.TUIServerURL != ""
+	needsHostAccess := hostSSHEnabled || ctx.TUI.ServerURL != ""
 	if needsHostAccess {
 		// Add host gateway for accessing host from container
 		// This enables hostDockerInternal (Docker) or hostContainersInternal (Podman)
@@ -135,11 +135,11 @@ func (r *ContainerRuntime) PrepareCommand(ctx *ExecutionContext) (*PreparedComma
 	}
 
 	// Add TUI server environment variables if set (for interactive mode)
-	if ctx.TUIServerURL != "" {
-		env["INVOWK_TUI_ADDR"] = ctx.TUIServerURL
+	if ctx.TUI.ServerURL != "" {
+		env["INVOWK_TUI_ADDR"] = ctx.TUI.ServerURL
 	}
-	if ctx.TUIServerToken != "" {
-		env["INVOWK_TUI_TOKEN"] = ctx.TUIServerToken
+	if ctx.TUI.ServerToken != "" {
+		env["INVOWK_TUI_TOKEN"] = ctx.TUI.ServerToken
 	}
 
 	// Build run options - enable TTY and Interactive for PTY attachment

--- a/internal/runtime/container_provision.go
+++ b/internal/runtime/container_provision.go
@@ -35,13 +35,13 @@ func (r *ContainerRuntime) ensureProvisionedImage(ctx *ExecutionContext, cfg inv
 
 	// Provision the image with invowk resources
 	if ctx.Verbose {
-		_, _ = fmt.Fprintf(ctx.Stdout, "Provisioning container with invowk resources...\n") // Verbose output; error non-critical
+		_, _ = fmt.Fprintf(ctx.IO.Stdout, "Provisioning container with invowk resources...\n") // Verbose output; error non-critical
 	}
 
 	result, err := r.provisioner.Provision(ctx.Context, baseImage)
 	if err != nil {
 		// If provisioning fails, warn but continue with base image
-		_, _ = fmt.Fprintf(ctx.Stderr, "Warning: failed to provision container, using base image: %v\n", err) // Warning output; error non-critical
+		_, _ = fmt.Fprintf(ctx.IO.Stderr, "Warning: failed to provision container, using base image: %v\n", err) // Warning output; error non-critical
 		return baseImage, nil, nil
 	}
 
@@ -90,15 +90,15 @@ func (r *ContainerRuntime) ensureImage(ctx *ExecutionContext, cfg invkfileContai
 
 	// Build the image
 	if ctx.Verbose {
-		_, _ = fmt.Fprintf(ctx.Stdout, "Building container image from %s...\n", containerfilePath) // Verbose output; error non-critical
+		_, _ = fmt.Fprintf(ctx.IO.Stdout, "Building container image from %s...\n", containerfilePath) // Verbose output; error non-critical
 	}
 
 	buildOpts := container.BuildOptions{
 		ContextDir: invowkDir,
 		Dockerfile: containerfile,
 		Tag:        imageTag,
-		Stdout:     ctx.Stdout,
-		Stderr:     ctx.Stderr,
+		Stdout:     ctx.IO.Stdout,
+		Stderr:     ctx.IO.Stderr,
 	}
 
 	if err := r.engine.Build(ctx.Context, buildOpts); err != nil {

--- a/internal/runtime/env.go
+++ b/internal/runtime/env.go
@@ -65,17 +65,17 @@ func buildRuntimeEnv(ctx *ExecutionContext, defaultMode invkfile.EnvInheritMode)
 	maps.Copy(env, ctx.SelectedImpl.Env.GetVars())
 
 	// 8. Extra env from context (flags, args)
-	maps.Copy(env, ctx.ExtraEnv)
+	maps.Copy(env, ctx.Env.ExtraEnv)
 
 	// 9. Runtime --env-file flag files
-	for _, path := range ctx.RuntimeEnvFiles {
+	for _, path := range ctx.Env.RuntimeEnvFiles {
 		if err := LoadEnvFileFromCwd(env, path); err != nil {
 			return nil, err
 		}
 	}
 
 	// 10. Runtime --env-var flag values (highest priority)
-	maps.Copy(env, ctx.RuntimeEnvVars)
+	maps.Copy(env, ctx.Env.RuntimeEnvVars)
 
 	return env, nil
 }
@@ -97,14 +97,14 @@ func resolveEnvInheritConfig(ctx *ExecutionContext, defaultMode invkfile.EnvInhe
 		}
 	}
 
-	if ctx.EnvInheritModeOverride != "" {
-		cfg.mode = ctx.EnvInheritModeOverride
+	if ctx.Env.InheritModeOverride != "" {
+		cfg.mode = ctx.Env.InheritModeOverride
 	}
-	if ctx.EnvInheritAllowOverride != nil {
-		cfg.allow = append([]string{}, ctx.EnvInheritAllowOverride...)
+	if ctx.Env.InheritAllowOverride != nil {
+		cfg.allow = append([]string{}, ctx.Env.InheritAllowOverride...)
 	}
-	if ctx.EnvInheritDenyOverride != nil {
-		cfg.deny = append([]string{}, ctx.EnvInheritDenyOverride...)
+	if ctx.Env.InheritDenyOverride != nil {
+		cfg.deny = append([]string{}, ctx.Env.InheritDenyOverride...)
 	}
 
 	return cfg

--- a/internal/runtime/env_test.go
+++ b/internal/runtime/env_test.go
@@ -55,9 +55,9 @@ func TestBuildRuntimeEnv_InheritAllowAndDeny(t *testing.T) {
 	}
 	cmd := testCommandWithScript("env", "echo test", invkfile.RuntimeNative)
 	ctx := NewExecutionContext(cmd, inv)
-	ctx.EnvInheritModeOverride = invkfile.EnvInheritAllow
-	ctx.EnvInheritAllowOverride = []string{"ALLOW_ME", "DENY_ME"}
-	ctx.EnvInheritDenyOverride = []string{"DENY_ME"}
+	ctx.Env.InheritModeOverride = invkfile.EnvInheritAllow
+	ctx.Env.InheritAllowOverride = []string{"ALLOW_ME", "DENY_ME"}
+	ctx.Env.InheritDenyOverride = []string{"DENY_ME"}
 
 	restoreAllow := testutil.MustSetenv(t, "ALLOW_ME", "allowed")
 	restoreDeny := testutil.MustSetenv(t, "DENY_ME", "denied")
@@ -164,7 +164,7 @@ func TestResolveEnvInheritConfig(t *testing.T) {
 		{
 			name: "context override takes precedence",
 			setupCtx: func(ctx *ExecutionContext) {
-				ctx.EnvInheritModeOverride = invkfile.EnvInheritNone
+				ctx.Env.InheritModeOverride = invkfile.EnvInheritNone
 			},
 			defaultMode: invkfile.EnvInheritAll,
 			wantMode:    invkfile.EnvInheritNone,
@@ -172,8 +172,8 @@ func TestResolveEnvInheritConfig(t *testing.T) {
 		{
 			name: "context override allow mode with allowlist",
 			setupCtx: func(ctx *ExecutionContext) {
-				ctx.EnvInheritModeOverride = invkfile.EnvInheritAllow
-				ctx.EnvInheritAllowOverride = []string{"PATH", "HOME"}
+				ctx.Env.InheritModeOverride = invkfile.EnvInheritAllow
+				ctx.Env.InheritAllowOverride = []string{"PATH", "HOME"}
 			},
 			defaultMode: invkfile.EnvInheritAll,
 			wantMode:    invkfile.EnvInheritAllow,
@@ -182,7 +182,7 @@ func TestResolveEnvInheritConfig(t *testing.T) {
 		{
 			name: "context denylist override",
 			setupCtx: func(ctx *ExecutionContext) {
-				ctx.EnvInheritDenyOverride = []string{"SECRET", "API_KEY"}
+				ctx.Env.InheritDenyOverride = []string{"SECRET", "API_KEY"}
 			},
 			defaultMode: invkfile.EnvInheritAll,
 			wantMode:    invkfile.EnvInheritAll,
@@ -206,7 +206,7 @@ func TestResolveEnvInheritConfig(t *testing.T) {
 					Name:           invkfile.RuntimeNative,
 					EnvInheritMode: invkfile.EnvInheritNone,
 				}}
-				ctx.EnvInheritModeOverride = invkfile.EnvInheritAll
+				ctx.Env.InheritModeOverride = invkfile.EnvInheritAll
 			},
 			defaultMode: invkfile.EnvInheritNone,
 			wantMode:    invkfile.EnvInheritAll,
@@ -382,9 +382,9 @@ func TestBuildRuntimeEnv_Precedence(t *testing.T) {
 	}
 
 	ctx := NewExecutionContext(cmd, inv)
-	ctx.ExtraEnv = map[string]string{"SHARED": "extra_env", "EXTRA_ONLY": "extra_value"}
-	ctx.RuntimeEnvFiles = []string{filepath.Join(tmpDir, "runtime.env")}
-	ctx.RuntimeEnvVars = map[string]string{"SHARED": "runtime_var", "RUNTIME_VAR_ONLY": "runtime_var"}
+	ctx.Env.ExtraEnv = map[string]string{"SHARED": "extra_env", "EXTRA_ONLY": "extra_value"}
+	ctx.Env.RuntimeEnvFiles = []string{filepath.Join(tmpDir, "runtime.env")}
+	ctx.Env.RuntimeEnvVars = map[string]string{"SHARED": "runtime_var", "RUNTIME_VAR_ONLY": "runtime_var"}
 
 	env, err := buildRuntimeEnv(ctx, invkfile.EnvInheritAll)
 	if err != nil {
@@ -547,8 +547,8 @@ func TestBuildRuntimeEnv_RuntimeFlags(t *testing.T) {
 	}
 	cmd := testCommandWithScript("flags-test", "echo test", invkfile.RuntimeNative)
 	ctx := NewExecutionContext(cmd, inv)
-	ctx.RuntimeEnvFiles = []string{"flag.env"}
-	ctx.RuntimeEnvVars = map[string]string{"FLAG_VAR": "from_flag_var", "SHARED": "flag_var_wins"}
+	ctx.Env.RuntimeEnvFiles = []string{"flag.env"}
+	ctx.Env.RuntimeEnvVars = map[string]string{"FLAG_VAR": "from_flag_var", "SHARED": "flag_var_wins"}
 
 	env, err := buildRuntimeEnv(ctx, invkfile.EnvInheritNone)
 	if err != nil {
@@ -629,9 +629,9 @@ func TestBuildRuntimeEnv_InheritModes(t *testing.T) {
 			}
 			cmd := testCommandWithScript("inherit-test", "echo test", invkfile.RuntimeNative)
 			ctx := NewExecutionContext(cmd, inv)
-			ctx.EnvInheritModeOverride = tt.mode
-			ctx.EnvInheritAllowOverride = tt.allow
-			ctx.EnvInheritDenyOverride = tt.deny
+			ctx.Env.InheritModeOverride = tt.mode
+			ctx.Env.InheritAllowOverride = tt.allow
+			ctx.Env.InheritDenyOverride = tt.deny
 
 			env, err := buildRuntimeEnv(ctx, invkfile.EnvInheritAll)
 			if err != nil {
@@ -661,7 +661,7 @@ func TestBuildRuntimeEnv_ExtraEnv(t *testing.T) {
 	}
 	cmd := testCommandWithScript("extra-env-test", "echo test", invkfile.RuntimeNative)
 	ctx := NewExecutionContext(cmd, inv)
-	ctx.ExtraEnv = map[string]string{
+	ctx.Env.ExtraEnv = map[string]string{
 		"INVOWK_FLAG_VERBOSE": "true",
 		"INVOWK_ARG_FILE":     "test.txt",
 		"ARG1":                "first",

--- a/internal/runtime/native.go
+++ b/internal/runtime/native.go
@@ -58,19 +58,19 @@ func (r *NativeRuntime) Execute(ctx *ExecutionContext) *Result {
 	}
 
 	// Create streaming output configuration
-	output := newStreamingOutput(ctx.Stdout, ctx.Stderr)
+	output := newStreamingOutput(ctx.IO.Stdout, ctx.IO.Stderr)
 
 	rtConfig := ctx.SelectedImpl.GetRuntimeConfig(ctx.SelectedRuntime)
 	if rtConfig == nil {
-		return r.executeShellCommon(ctx, script, output, nil, ctx.Stdin)
+		return r.executeShellCommon(ctx, script, output, nil, ctx.IO.Stdin)
 	}
 
 	interpInfo := rtConfig.ResolveInterpreterFromScript(script)
 	if interpInfo.Found {
-		return r.executeInterpreterCommon(ctx, script, interpInfo, output, nil, ctx.Stdin)
+		return r.executeInterpreterCommon(ctx, script, interpInfo, output, nil, ctx.IO.Stdin)
 	}
 
-	return r.executeShellCommon(ctx, script, output, nil, ctx.Stdin)
+	return r.executeShellCommon(ctx, script, output, nil, ctx.IO.Stdin)
 }
 
 // ExecuteCapture runs a command and captures its output

--- a/internal/runtime/runtime_env_test.go
+++ b/internal/runtime/runtime_env_test.go
@@ -58,8 +58,8 @@ func TestRuntime_ScriptNotFound(t *testing.T) {
 	t.Run("native runtime", func(t *testing.T) {
 		rt := NewNativeRuntime()
 		ctx := NewExecutionContext(cmd, inv)
-		ctx.Stdout = &bytes.Buffer{}
-		ctx.Stderr = &bytes.Buffer{}
+		ctx.IO.Stdout = &bytes.Buffer{}
+		ctx.IO.Stderr = &bytes.Buffer{}
 
 		result := rt.Execute(ctx)
 		if result.Error == nil {
@@ -72,8 +72,8 @@ func TestRuntime_ScriptNotFound(t *testing.T) {
 		rt := NewVirtualRuntime(false)
 		ctx := NewExecutionContext(cmdVirtual, inv)
 		ctx.Context = context.Background()
-		ctx.Stdout = &bytes.Buffer{}
-		ctx.Stderr = &bytes.Buffer{}
+		ctx.IO.Stdout = &bytes.Buffer{}
+		ctx.IO.Stderr = &bytes.Buffer{}
 
 		result := rt.Execute(ctx)
 		if result.Error == nil {
@@ -119,8 +119,8 @@ func TestRuntime_EnvironmentVariables(t *testing.T) {
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {

--- a/internal/runtime/runtime_native_interpreter_test.go
+++ b/internal/runtime/runtime_native_interpreter_test.go
@@ -46,8 +46,8 @@ print("Hello from Python")`
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -91,8 +91,8 @@ print(f"Python version: {sys.version_info.major}.{sys.version_info.minor}")`
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -138,8 +138,8 @@ print(f"arg1={sys.argv[1] if len(sys.argv) > 1 else 'none'}")`
 	ctx.PositionalArgs = []string{"hello-world"}
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -188,8 +188,8 @@ print("Hello from Python file")
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -227,8 +227,8 @@ func TestNativeRuntime_InterpreterNotFound(t *testing.T) {
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode == 0 {

--- a/internal/runtime/runtime_native_test.go
+++ b/internal/runtime/runtime_native_test.go
@@ -40,8 +40,8 @@ func TestNativeRuntime_InlineScript(t *testing.T) {
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -82,8 +82,8 @@ echo "Line 3"`
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -128,8 +128,8 @@ echo "Hello from script file"
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -168,8 +168,8 @@ func TestNativeRuntime_PositionalArgs(t *testing.T) {
 	ctx.PositionalArgs = []string{"hello", "world"}
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -214,8 +214,8 @@ func TestNativeRuntime_PositionalArgs_Empty(t *testing.T) {
 	// No positional args set
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -254,8 +254,8 @@ func TestNativeRuntime_PositionalArgs_SpecialChars(t *testing.T) {
 	ctx.PositionalArgs = []string{"hello world with spaces"}
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -385,8 +385,8 @@ echo "ARG1=${ARG1:-unset}"`
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -443,8 +443,8 @@ func TestNativeRuntime_InvalidWorkingDirectory(t *testing.T) {
 	ctx := NewExecutionContext(cmd, inv)
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 
@@ -493,8 +493,8 @@ func TestNativeRuntime_ExitCode(t *testing.T) {
 			cmd := testCommandWithScript("exit-test", tt.script, invkfile.RuntimeNative)
 			rt := NewNativeRuntime()
 			ctx := NewExecutionContext(cmd, inv)
-			ctx.Stdout = &bytes.Buffer{}
-			ctx.Stderr = &bytes.Buffer{}
+			ctx.IO.Stdout = &bytes.Buffer{}
+			ctx.IO.Stderr = &bytes.Buffer{}
 
 			result := rt.Execute(ctx)
 			if result.ExitCode != tt.expectedCode {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -61,17 +61,17 @@ func TestNewExecutionContext(t *testing.T) {
 	if ctx.Context == nil {
 		t.Error("NewExecutionContext() Context should be background context")
 	}
-	if ctx.Stdout != os.Stdout {
-		t.Error("NewExecutionContext() Stdout should default to os.Stdout")
+	if ctx.IO.Stdout != os.Stdout {
+		t.Error("NewExecutionContext() IO.Stdout should default to os.Stdout")
 	}
-	if ctx.Stderr != os.Stderr {
-		t.Error("NewExecutionContext() Stderr should default to os.Stderr")
+	if ctx.IO.Stderr != os.Stderr {
+		t.Error("NewExecutionContext() IO.Stderr should default to os.Stderr")
 	}
-	if ctx.Stdin != os.Stdin {
-		t.Error("NewExecutionContext() Stdin should default to os.Stdin")
+	if ctx.IO.Stdin != os.Stdin {
+		t.Error("NewExecutionContext() IO.Stdin should default to os.Stdin")
 	}
-	if ctx.ExtraEnv == nil {
-		t.Error("NewExecutionContext() ExtraEnv should be initialized")
+	if ctx.Env.ExtraEnv == nil {
+		t.Error("NewExecutionContext() Env.ExtraEnv should be initialized")
 	}
 	if ctx.SelectedRuntime != invkfile.RuntimeNative {
 		t.Errorf("NewExecutionContext() SelectedRuntime = %q, want %q", ctx.SelectedRuntime, invkfile.RuntimeNative)
@@ -402,8 +402,8 @@ func TestRegistry_Execute(t *testing.T) {
 
 			cmd := testCommandWithScript("test", "echo test", tt.runtime)
 			ctx := NewExecutionContext(cmd, inv)
-			ctx.Stdout = &bytes.Buffer{}
-			ctx.Stderr = &bytes.Buffer{}
+			ctx.IO.Stdout = &bytes.Buffer{}
+			ctx.IO.Stderr = &bytes.Buffer{}
 
 			result := reg.Execute(ctx)
 
@@ -554,16 +554,16 @@ func TestExecutionContext_CustomOverrides(t *testing.T) {
 
 	// Set custom overrides
 	ctx.Context = context.TODO()
-	ctx.Stdout = &bytes.Buffer{}
-	ctx.Stderr = &bytes.Buffer{}
-	ctx.ExtraEnv["CUSTOM"] = "value"
+	ctx.IO.Stdout = &bytes.Buffer{}
+	ctx.IO.Stderr = &bytes.Buffer{}
+	ctx.Env.ExtraEnv["CUSTOM"] = "value"
 	ctx.WorkDir = "/custom/dir"
 	ctx.Verbose = true
 	ctx.PositionalArgs = []string{"arg1", "arg2"}
-	ctx.RuntimeEnvFiles = []string{".env"}
-	ctx.RuntimeEnvVars = map[string]string{"VAR": "val"}
-	ctx.TUIServerURL = "http://localhost:8080"
-	ctx.TUIServerToken = "token123"
+	ctx.Env.RuntimeEnvFiles = []string{".env"}
+	ctx.Env.RuntimeEnvVars = map[string]string{"VAR": "val"}
+	ctx.TUI.ServerURL = "http://localhost:8080"
+	ctx.TUI.ServerToken = "token123"
 
 	// Verify overrides are set
 	if ctx.WorkDir != "/custom/dir" {
@@ -575,13 +575,13 @@ func TestExecutionContext_CustomOverrides(t *testing.T) {
 	if len(ctx.PositionalArgs) != 2 {
 		t.Errorf("PositionalArgs length = %d, want 2", len(ctx.PositionalArgs))
 	}
-	if ctx.ExtraEnv["CUSTOM"] != "value" {
-		t.Error("ExtraEnv not set correctly")
+	if ctx.Env.ExtraEnv["CUSTOM"] != "value" {
+		t.Error("Env.ExtraEnv not set correctly")
 	}
-	if ctx.TUIServerURL != "http://localhost:8080" {
-		t.Error("TUIServerURL not set correctly")
+	if ctx.TUI.ServerURL != "http://localhost:8080" {
+		t.Error("TUI.ServerURL not set correctly")
 	}
-	if ctx.TUIServerToken != "token123" {
-		t.Error("TUIServerToken not set correctly")
+	if ctx.TUI.ServerToken != "token123" {
+		t.Error("TUI.ServerToken not set correctly")
 	}
 }

--- a/internal/runtime/runtime_virtual_integration_test.go
+++ b/internal/runtime/runtime_virtual_integration_test.go
@@ -42,8 +42,8 @@ func testVirtualCommandSubstitution(t *testing.T) {
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -70,8 +70,8 @@ func testVirtualPipelines(t *testing.T) {
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -103,8 +103,8 @@ EOF`
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -140,8 +140,8 @@ echo "Length: ${#MYVAR}"`
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -180,8 +180,8 @@ echo "Product: $((4 * 5))"`
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -214,8 +214,8 @@ false || echo "OR_FALLBACK"`
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -262,8 +262,8 @@ func TestVirtualRuntime_ScriptFileFromSubdir(t *testing.T) {
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {

--- a/internal/runtime/runtime_virtual_test.go
+++ b/internal/runtime/runtime_virtual_test.go
@@ -35,8 +35,8 @@ func TestVirtualRuntime_InlineScript(t *testing.T) {
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -73,8 +73,8 @@ echo "Done"`
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -115,8 +115,8 @@ func TestVirtualRuntime_ScriptFile(t *testing.T) {
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -177,8 +177,8 @@ func TestVirtualRuntime_PositionalArgs(t *testing.T) {
 	ctx.PositionalArgs = []string{"foo", "bar"}
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -220,8 +220,8 @@ func TestVirtualRuntime_PositionalArgs_ArgCount(t *testing.T) {
 	ctx.PositionalArgs = []string{"a", "b", "c", "d", "e"}
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -257,8 +257,8 @@ func TestVirtualRuntime_PositionalArgs_Empty(t *testing.T) {
 	// No positional args set
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -306,8 +306,8 @@ echo "ARG1=${ARG1:-unset}"`
 	ctx.Context = context.Background()
 
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode != 0 {
@@ -362,8 +362,8 @@ func TestVirtualRuntime_RejectsInterpreter(t *testing.T) {
 
 	// Test Execute method (as a safety net)
 	var stdout bytes.Buffer
-	ctx.Stdout = &stdout
-	ctx.Stderr = &bytes.Buffer{}
+	ctx.IO.Stdout = &stdout
+	ctx.IO.Stderr = &bytes.Buffer{}
 
 	result := rt.Execute(ctx)
 	if result.ExitCode == 0 {
@@ -400,8 +400,8 @@ func TestVirtualRuntime_ContextCancellation(t *testing.T) {
 	execCtx.Context = ctx
 
 	var stdout bytes.Buffer
-	execCtx.Stdout = &stdout
-	execCtx.Stderr = &bytes.Buffer{}
+	execCtx.IO.Stdout = &stdout
+	execCtx.IO.Stderr = &bytes.Buffer{}
 
 	// Cancel the context after a short delay
 	go func() {
@@ -446,8 +446,8 @@ func TestVirtualRuntime_ExitCode(t *testing.T) {
 			rt := NewVirtualRuntime(false)
 			ctx := NewExecutionContext(cmd, inv)
 			ctx.Context = context.Background()
-			ctx.Stdout = &bytes.Buffer{}
-			ctx.Stderr = &bytes.Buffer{}
+			ctx.IO.Stdout = &bytes.Buffer{}
+			ctx.IO.Stderr = &bytes.Buffer{}
 
 			result := rt.Execute(ctx)
 			if result.ExitCode != tt.expectedCode {

--- a/internal/runtime/virtual.go
+++ b/internal/runtime/virtual.go
@@ -113,7 +113,7 @@ func (r *VirtualRuntime) Execute(ctx *ExecutionContext) *Result {
 	opts := []interp.RunnerOption{
 		interp.Dir(workDir),
 		interp.Env(expand.ListEnviron(EnvToSlice(env)...)),
-		interp.StdIO(ctx.Stdin, ctx.Stdout, ctx.Stderr),
+		interp.StdIO(ctx.IO.Stdin, ctx.IO.Stdout, ctx.IO.Stderr),
 		interp.ExecHandlers(r.execHandler),
 	}
 


### PR DESCRIPTION
## Summary

Resolves #13 - Decompose ExecutionContext into Focused Types

- Introduces `IOContext`, `EnvContext`, and `TUIContext` sub-types to break down the 21-field "god object"
- Adds helper functions for common patterns: `DefaultIO()`, `CaptureIO()`, `DefaultEnv()`, `WithVar()`, `IsConfigured()`
- Renames env inherit fields inside EnvContext for consistency (`EnvInheritModeOverride` → `InheritModeOverride`, etc.)
- Updates all internal runtime files and callers to use composition accessors (`ctx.IO.*`, `ctx.Env.*`, `ctx.TUI.*`)

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `make test-cli` passes
- [x] `make license-check` passes
- [x] `make tidy` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)