### PR TITLE
refactor(runtime): extract EnvBuilder interface (#15)

### DIFF
--- a/internal/runtime/container_exec.go
+++ b/internal/runtime/container_exec.go
@@ -66,7 +66,7 @@ func (r *ContainerRuntime) prepareContainerExecution(ctx *ExecutionContext) (*co
 	}
 
 	// Build environment
-	env, err := buildRuntimeEnv(ctx, invkfile.EnvInheritNone)
+	env, err := r.envBuilder.Build(ctx, invkfile.EnvInheritNone)
 	if err != nil {
 		if provisionCleanup != nil {
 			provisionCleanup()

--- a/internal/runtime/container_prepare.go
+++ b/internal/runtime/container_prepare.go
@@ -58,7 +58,7 @@ func (r *ContainerRuntime) PrepareCommand(ctx *ExecutionContext) (*PreparedComma
 	}
 
 	// Build environment
-	env, err := buildRuntimeEnv(ctx, invkfile.EnvInheritNone)
+	env, err := r.envBuilder.Build(ctx, invkfile.EnvInheritNone)
 	if err != nil {
 		if provisionCleanup != nil {
 			provisionCleanup()

--- a/internal/runtime/env_builder.go
+++ b/internal/runtime/env_builder.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package runtime
+
+import (
+	"maps"
+
+	"invowk-cli/pkg/invkfile"
+)
+
+type (
+	// EnvBuilder builds environment variables for command execution.
+	// It applies a 10-level precedence hierarchy (higher number wins):
+	//
+	//  1. Host environment (filtered by inherit mode)
+	//  2. Root-level env.files
+	//  3. Command-level env.files
+	//  4. Implementation-level env.files
+	//  5. Root-level env.vars
+	//  6. Command-level env.vars
+	//  7. Implementation-level env.vars
+	//  8. ExtraEnv (INVOWK_FLAG_*, INVOWK_ARG_*, ARGn, ARGC)
+	//  9. RuntimeEnvFiles (--env-file flag)
+	//  10. RuntimeEnvVars (--env-var flag) - HIGHEST priority
+	//
+	// This interface enables:
+	//   - Testability: runtimes can be tested with mock env builders
+	//   - Flexibility: alternative env building strategies for specific use cases
+	//   - Documentation: the precedence hierarchy is explicitly documented
+	EnvBuilder interface {
+		Build(ctx *ExecutionContext, defaultMode invkfile.EnvInheritMode) (map[string]string, error)
+	}
+
+	// DefaultEnvBuilder implements the standard 10-level precedence for environment building.
+	DefaultEnvBuilder struct{}
+
+	// MockEnvBuilder is a test helper that returns a fixed environment map.
+	// It can be used to test runtimes in isolation without real env building.
+	MockEnvBuilder struct {
+		// Env is the environment map to return from Build
+		Env map[string]string
+		// Err is the error to return from Build (if non-nil)
+		Err error
+	}
+)
+
+// NewDefaultEnvBuilder creates a new DefaultEnvBuilder.
+func NewDefaultEnvBuilder() *DefaultEnvBuilder {
+	return &DefaultEnvBuilder{}
+}
+
+// Build constructs the environment map following the 10-level precedence.
+// The defaultMode parameter specifies the default inherit mode when not
+// overridden by runtime config or CLI flags.
+func (b *DefaultEnvBuilder) Build(ctx *ExecutionContext, defaultMode invkfile.EnvInheritMode) (map[string]string, error) {
+	cfg := resolveEnvInheritConfig(ctx, defaultMode)
+	env := buildHostEnv(cfg)
+
+	// Determine the base path for resolving env files
+	basePath := ctx.Invkfile.GetScriptBasePath()
+
+	// 2. Root-level env.files
+	for _, path := range ctx.Invkfile.Env.GetFiles() {
+		if err := LoadEnvFile(env, path, basePath); err != nil {
+			return nil, err
+		}
+	}
+
+	// 3. Command-level env.files
+	for _, path := range ctx.Command.Env.GetFiles() {
+		if err := LoadEnvFile(env, path, basePath); err != nil {
+			return nil, err
+		}
+	}
+
+	// 4. Implementation-level env.files
+	for _, path := range ctx.SelectedImpl.Env.GetFiles() {
+		if err := LoadEnvFile(env, path, basePath); err != nil {
+			return nil, err
+		}
+	}
+
+	// 5. Root-level env.vars
+	maps.Copy(env, ctx.Invkfile.Env.GetVars())
+
+	// 6. Command-level env.vars
+	maps.Copy(env, ctx.Command.Env.GetVars())
+
+	// 7. Implementation-level env.vars
+	maps.Copy(env, ctx.SelectedImpl.Env.GetVars())
+
+	// 8. Extra env from context (flags, args)
+	maps.Copy(env, ctx.Env.ExtraEnv)
+
+	// 9. Runtime --env-file flag files
+	for _, path := range ctx.Env.RuntimeEnvFiles {
+		if err := LoadEnvFileFromCwd(env, path); err != nil {
+			return nil, err
+		}
+	}
+
+	// 10. Runtime --env-var flag values (highest priority)
+	maps.Copy(env, ctx.Env.RuntimeEnvVars)
+
+	return env, nil
+}
+
+// Build returns the mock environment or error.
+func (m *MockEnvBuilder) Build(_ *ExecutionContext, _ invkfile.EnvInheritMode) (map[string]string, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	if m.Env == nil {
+		return make(map[string]string), nil
+	}
+	// Return a copy to prevent mutations
+	result := make(map[string]string, len(m.Env))
+	maps.Copy(result, m.Env)
+	return result, nil
+}

--- a/internal/runtime/env_builder_test.go
+++ b/internal/runtime/env_builder_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"invowk-cli/pkg/invkfile"
+)
+
+// TestEnvBuilder_InterfaceContract verifies that DefaultEnvBuilder and MockEnvBuilder
+// both satisfy the EnvBuilder interface.
+func TestEnvBuilder_InterfaceContract(t *testing.T) {
+	var _ EnvBuilder = &DefaultEnvBuilder{}
+	var _ EnvBuilder = &MockEnvBuilder{}
+}
+
+// TestMockEnvBuilder_ReturnsConfiguredEnv verifies that MockEnvBuilder returns
+// the configured environment map.
+func TestMockEnvBuilder_ReturnsConfiguredEnv(t *testing.T) {
+	mock := &MockEnvBuilder{
+		Env: map[string]string{
+			"TEST_VAR": "test_value",
+			"FOO":      "bar",
+		},
+	}
+
+	env, err := mock.Build(nil, invkfile.EnvInheritAll)
+	if err != nil {
+		t.Fatalf("MockEnvBuilder.Build() unexpected error: %v", err)
+	}
+
+	if got := env["TEST_VAR"]; got != "test_value" {
+		t.Errorf("TEST_VAR = %q, want %q", got, "test_value")
+	}
+	if got := env["FOO"]; got != "bar" {
+		t.Errorf("FOO = %q, want %q", got, "bar")
+	}
+}
+
+// TestMockEnvBuilder_ReturnsCopy verifies that MockEnvBuilder returns a copy
+// of the environment, not the original map (preventing mutation).
+func TestMockEnvBuilder_ReturnsCopy(t *testing.T) {
+	original := map[string]string{"KEY": "value"}
+	mock := &MockEnvBuilder{Env: original}
+
+	env1, _ := mock.Build(nil, invkfile.EnvInheritAll)
+	env1["KEY"] = "mutated"
+
+	env2, _ := mock.Build(nil, invkfile.EnvInheritAll)
+	if got := env2["KEY"]; got != "value" {
+		t.Errorf("MockEnvBuilder.Build() should return a copy; got mutated value %q", got)
+	}
+}
+
+// TestMockEnvBuilder_ReturnsError verifies that MockEnvBuilder returns
+// the configured error.
+func TestMockEnvBuilder_ReturnsError(t *testing.T) {
+	expectedErr := errors.New("mock error")
+	mock := &MockEnvBuilder{
+		Err: expectedErr,
+		Env: map[string]string{"KEY": "value"}, // Should be ignored when Err is set
+	}
+
+	env, err := mock.Build(nil, invkfile.EnvInheritAll)
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("MockEnvBuilder.Build() error = %v, want %v", err, expectedErr)
+	}
+	if env != nil {
+		t.Errorf("MockEnvBuilder.Build() should return nil env when error is set")
+	}
+}
+
+// TestMockEnvBuilder_NilEnvReturnsEmptyMap verifies that MockEnvBuilder returns
+// an empty map when Env is nil (not nil).
+func TestMockEnvBuilder_NilEnvReturnsEmptyMap(t *testing.T) {
+	mock := &MockEnvBuilder{Env: nil}
+
+	env, err := mock.Build(nil, invkfile.EnvInheritAll)
+	if err != nil {
+		t.Fatalf("MockEnvBuilder.Build() unexpected error: %v", err)
+	}
+	if env == nil {
+		t.Error("MockEnvBuilder.Build() should return empty map, not nil")
+	}
+	if len(env) != 0 {
+		t.Errorf("MockEnvBuilder.Build() should return empty map, got %v", env)
+	}
+}
+
+// TestNewDefaultEnvBuilder verifies that NewDefaultEnvBuilder creates a valid builder.
+func TestNewDefaultEnvBuilder(t *testing.T) {
+	builder := NewDefaultEnvBuilder()
+	if builder == nil {
+		t.Error("NewDefaultEnvBuilder() returned nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract environment building logic into `EnvBuilder` interface with explicit 10-level precedence documentation
- Add `DefaultEnvBuilder` implementation (moves logic from `buildRuntimeEnv()`)
- Add `MockEnvBuilder` for testing runtimes in isolation
- Inject `EnvBuilder` into all three runtimes via functional options pattern

Closes #15

## Changes

### New Files
- `internal/runtime/env_builder.go` - Interface, DefaultEnvBuilder, MockEnvBuilder
- `internal/runtime/env_builder_test.go` - Interface contract and mock tests

### Modified Files
- `internal/runtime/native.go` - Add `envBuilder` field, `WithEnvBuilder()` option
- `internal/runtime/virtual.go` - Add `envBuilder` field, `WithVirtualEnvBuilder()` option
- `internal/runtime/container.go` - Add `envBuilder` field, `WithContainerEnvBuilder()` option
- `internal/runtime/container_exec.go` - Use `r.envBuilder.Build()`
- `internal/runtime/container_prepare.go` - Use `r.envBuilder.Build()`
- `internal/runtime/env.go` - Remove `buildRuntimeEnv()` (moved to DefaultEnvBuilder)
- `internal/runtime/env_test.go` - Update to use `NewDefaultEnvBuilder().Build()`

## Test plan

- [x] `make lint` passes
- [x] `make license-check` passes
- [x] `make test` passes (full test suite)
- [x] New `env_builder_test.go` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)