### PR TITLE
refactor(runtime): extract provisioning to provision package (#16)

### DIFF
--- a/cmd/invowk/cmd.go
+++ b/cmd/invowk/cmd.go
@@ -30,6 +30,8 @@ var (
 	runtimeOverride string
 	// fromSource allows specifying the source for disambiguation
 	fromSource string
+	// forceRebuild forces rebuilding of container images, bypassing cache
+	forceRebuild bool
 	// sshServerInstance is the global SSH server instance
 	sshServerInstance *sshserver.Server
 	// sshServerMu protects the SSH server instance
@@ -165,6 +167,7 @@ func init() {
 	cmdCmd.Flags().BoolVarP(&listFlag, "list", "l", false, "list all available commands")
 	cmdCmd.PersistentFlags().StringVarP(&runtimeOverride, "runtime", "r", "", "override the runtime (must be allowed by the command)")
 	cmdCmd.PersistentFlags().StringVar(&fromSource, "from", "", "source to run command from (e.g., 'invkfile' or module name)")
+	cmdCmd.PersistentFlags().BoolVar(&forceRebuild, "force-rebuild", false, "force rebuild of container images (container runtime only)")
 
 	// Dynamically add discovered commands
 	// This happens at init time to enable shell completion

--- a/cmd/invowk/cmd_execute.go
+++ b/cmd/invowk/cmd_execute.go
@@ -137,8 +137,9 @@ func runCommandWithFlags(cmdName string, args []string, flagValues map[string]st
 	ctx.Verbose = verbose
 	ctx.SelectedRuntime = selectedRuntime
 	ctx.SelectedImpl = script
-	ctx.PositionalArgs = args     // Enable shell positional parameter access ($1, $2, etc.)
-	ctx.WorkDir = workdirOverride // CLI override for working directory (--workdir flag)
+	ctx.PositionalArgs = args       // Enable shell positional parameter access ($1, $2, etc.)
+	ctx.WorkDir = workdirOverride   // CLI override for working directory (--workdir flag)
+	ctx.ForceRebuild = forceRebuild // Force rebuild container images (--force-rebuild flag)
 
 	// Set environment configuration
 	ctx.Env.RuntimeEnvFiles = runtimeEnvFiles // Env files from --env-file flag

--- a/internal/provision/config.go
+++ b/internal/provision/config.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package provision
+
+import (
+	"os"
+	"path/filepath"
+
+	"invowk-cli/internal/config"
+)
+
+type (
+	// Config holds configuration for auto-provisioning invowk resources into containers.
+	Config struct {
+		// Enabled controls whether auto-provisioning is active
+		Enabled bool
+
+		// ForceRebuild bypasses cached images and forces a rebuild
+		ForceRebuild bool
+
+		// InvowkBinaryPath is the path to the invowk binary on the host.
+		// If empty, os.Executable() will be used.
+		InvowkBinaryPath string
+
+		// ModulesPaths are paths to module directories on the host.
+		// These are discovered from config search paths and user commands dir.
+		ModulesPaths []string
+
+		// InvkfilePath is the path to the current invkfile being executed.
+		// This is used to determine what needs to be provisioned.
+		InvkfilePath string
+
+		// BinaryMountPath is where to place the binary in the container.
+		// Default: /invowk/bin
+		BinaryMountPath string
+
+		// ModulesMountPath is where to place modules in the container.
+		// Default: /invowk/modules
+		ModulesMountPath string
+
+		// CacheDir is where to store cached provisioned images metadata.
+		// Default: ~/.cache/invowk/provision
+		CacheDir string
+	}
+
+	// Option is a functional option for configuring a Config.
+	Option func(*Config)
+)
+
+// DefaultConfig returns a Config with default values.
+func DefaultConfig() *Config {
+	binaryPath, _ := os.Executable()
+
+	// Discover module paths from user commands dir and config
+	var modulesPaths []string
+	if userDir, err := config.CommandsDir(); err == nil {
+		if info, err := os.Stat(userDir); err == nil && info.IsDir() {
+			modulesPaths = append(modulesPaths, userDir)
+		}
+	}
+
+	cacheDir := ""
+	if home, err := os.UserHomeDir(); err == nil {
+		cacheDir = filepath.Join(home, ".cache", "invowk", "provision")
+	}
+
+	return &Config{
+		Enabled:          true,
+		ForceRebuild:     false,
+		InvowkBinaryPath: binaryPath,
+		ModulesPaths:     modulesPaths,
+		BinaryMountPath:  "/invowk/bin",
+		ModulesMountPath: "/invowk/modules",
+		CacheDir:         cacheDir,
+	}
+}
+
+// WithForceRebuild returns an Option that sets ForceRebuild on the config.
+func WithForceRebuild(force bool) Option {
+	return func(c *Config) {
+		c.ForceRebuild = force
+	}
+}
+
+// WithEnabled returns an Option that sets Enabled on the config.
+func WithEnabled(enabled bool) Option {
+	return func(c *Config) {
+		c.Enabled = enabled
+	}
+}
+
+// WithInvowkBinaryPath returns an Option that sets InvowkBinaryPath on the config.
+func WithInvowkBinaryPath(path string) Option {
+	return func(c *Config) {
+		c.InvowkBinaryPath = path
+	}
+}
+
+// WithModulesPaths returns an Option that sets ModulesPaths on the config.
+func WithModulesPaths(paths []string) Option {
+	return func(c *Config) {
+		c.ModulesPaths = paths
+	}
+}
+
+// WithInvkfilePath returns an Option that sets InvkfilePath on the config.
+func WithInvkfilePath(path string) Option {
+	return func(c *Config) {
+		c.InvkfilePath = path
+	}
+}
+
+// WithCacheDir returns an Option that sets CacheDir on the config.
+func WithCacheDir(dir string) Option {
+	return func(c *Config) {
+		c.CacheDir = dir
+	}
+}
+
+// Apply applies the given options to the config.
+func (c *Config) Apply(opts ...Option) {
+	for _, opt := range opts {
+		opt(c)
+	}
+}

--- a/internal/provision/doc.go
+++ b/internal/provision/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package provision handles container image provisioning for invowk.
+//
+// This package provides functionality to create ephemeral container image layers
+// that include invowk resources (binary, modules, etc.) on top of a base image.
+// The provisioned images are cached based on content hashes for fast reuse.
+//
+// The main entry point is the Provisioner interface, implemented by LayerProvisioner:
+//
+//	provisioner := provision.NewLayerProvisioner(engine, cfg)
+//	result, err := provisioner.Provision(ctx, "debian:stable-slim")
+//	// result.ImageTag contains the provisioned image to use
+//
+// Provisioned images enable nested invowk commands inside containers by bundling
+// the invowk binary and user modules into the container's filesystem.
+package provision

--- a/internal/provision/dockerfile.go
+++ b/internal/provision/dockerfile.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package provision
+
+import (
+	"fmt"
+	"strings"
+)
+
+// generateDockerfile creates the Dockerfile content for the provisioned image.
+func (p *LayerProvisioner) generateDockerfile(baseImage string) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "FROM %s\n\n", baseImage)
+	sb.WriteString("# Invowk auto-provisioned layer\n")
+	sb.WriteString("# This layer adds invowk binary and modules to enable nested invowk commands\n\n")
+
+	// Copy invowk binary
+	if p.config.InvowkBinaryPath != "" {
+		binaryPath := p.config.BinaryMountPath
+		sb.WriteString("# Install invowk binary\n")
+		fmt.Fprintf(&sb, "COPY invowk %s/invowk\n", binaryPath)
+		fmt.Fprintf(&sb, "RUN chmod +x %s/invowk\n\n", binaryPath)
+	}
+
+	// Copy modules
+	modulesPath := p.config.ModulesMountPath
+	sb.WriteString("# Install modules\n")
+	fmt.Fprintf(&sb, "COPY modules/ %s/\n\n", modulesPath)
+
+	// Set environment variables
+	sb.WriteString("# Configure environment\n")
+	if p.config.InvowkBinaryPath != "" {
+		fmt.Fprintf(&sb, "ENV PATH=\"%s:$PATH\"\n", p.config.BinaryMountPath)
+	}
+	fmt.Fprintf(&sb, "ENV INVOWK_MODULE_PATH=\"%s\"\n", modulesPath)
+
+	return sb.String()
+}
+
+// buildEnvVars returns environment variables to set in the container.
+func (p *LayerProvisioner) buildEnvVars() map[string]string {
+	env := make(map[string]string)
+
+	// PATH is set in the Dockerfile, but we also set it here for consistency
+	if p.config.InvowkBinaryPath != "" {
+		env["PATH"] = p.config.BinaryMountPath + ":/usr/local/bin:/usr/bin:/bin"
+	}
+
+	env["INVOWK_MODULE_PATH"] = p.config.ModulesMountPath
+
+	return env
+}

--- a/internal/provision/layer_provisioner_test.go
+++ b/internal/provision/layer_provisioner_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package provision
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLayerProvisionerGenerateDockerfile(t *testing.T) {
+	cfg := &Config{
+		Enabled:          true,
+		InvowkBinaryPath: "/usr/bin/invowk",
+		BinaryMountPath:  "/invowk/bin",
+		ModulesMountPath: "/invowk/modules",
+	}
+
+	provisioner := &LayerProvisioner{
+		config: cfg,
+	}
+
+	dockerfile := provisioner.generateDockerfile("debian:stable-slim")
+
+	// Verify Dockerfile content
+	if !strings.Contains(dockerfile, "FROM debian:stable-slim") {
+		t.Error("Expected FROM debian:stable-slim")
+	}
+
+	if !strings.Contains(dockerfile, "COPY invowk /invowk/bin/invowk") {
+		t.Error("Expected COPY invowk")
+	}
+
+	if !strings.Contains(dockerfile, "COPY modules/ /invowk/modules/") {
+		t.Error("Expected COPY modules/")
+	}
+
+	if !strings.Contains(dockerfile, "ENV PATH=\"/invowk/bin:$PATH\"") {
+		t.Error("Expected PATH env var")
+	}
+
+	if !strings.Contains(dockerfile, "ENV INVOWK_MODULE_PATH=\"/invowk/modules\"") {
+		t.Error("Expected INVOWK_MODULE_PATH env var")
+	}
+}
+
+func TestLayerProvisionerBuildEnvVars(t *testing.T) {
+	cfg := &Config{
+		Enabled:          true,
+		InvowkBinaryPath: "/usr/bin/invowk",
+		BinaryMountPath:  "/invowk/bin",
+		ModulesMountPath: "/invowk/modules",
+	}
+
+	provisioner := &LayerProvisioner{
+		config: cfg,
+	}
+
+	envVars := provisioner.buildEnvVars()
+
+	if envVars["INVOWK_MODULE_PATH"] != "/invowk/modules" {
+		t.Errorf("Expected INVOWK_MODULE_PATH=/invowk/modules, got %s", envVars["INVOWK_MODULE_PATH"])
+	}
+
+	if !strings.Contains(envVars["PATH"], "/invowk/bin") {
+		t.Errorf("Expected PATH to contain /invowk/bin, got %s", envVars["PATH"])
+	}
+}
+
+func TestLayerProvisionerConfigAccessor(t *testing.T) {
+	cfg := &Config{
+		Enabled:      true,
+		ForceRebuild: true,
+	}
+
+	provisioner := &LayerProvisioner{
+		config: cfg,
+	}
+
+	if provisioner.Config() != cfg {
+		t.Error("Config() should return the provisioner's config")
+	}
+
+	if !provisioner.Config().ForceRebuild {
+		t.Error("Expected ForceRebuild to be true")
+	}
+}
+
+func TestNewLayerProvisionerWithNilConfig(t *testing.T) {
+	// NewLayerProvisioner should use DefaultConfig when passed nil
+	provisioner := NewLayerProvisioner(nil, nil)
+
+	if provisioner.config == nil {
+		t.Fatal("Expected config to be set to defaults when nil passed")
+	}
+
+	if !provisioner.config.Enabled {
+		t.Error("Expected Enabled to be true by default")
+	}
+
+	if provisioner.config.BinaryMountPath != "/invowk/bin" {
+		t.Errorf("Expected BinaryMountPath to be /invowk/bin, got %s", provisioner.config.BinaryMountPath)
+	}
+}

--- a/internal/provision/provisioner.go
+++ b/internal/provision/provisioner.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package provision
+
+import "context"
+
+type (
+	// Provisioner prepares container images with invowk resources.
+	// Implementations should cache provisioned images based on content hashes
+	// to enable fast reuse when resources haven't changed.
+	Provisioner interface {
+		// Provision adds invowk resources (binary, modules) to a base image.
+		// Returns provisioned image tag and cleanup function.
+		// The cleanup function removes temporary build resources (not the cached image).
+		Provision(ctx context.Context, baseImage string) (*Result, error)
+	}
+
+	// Result contains the output of a provisioning operation.
+	Result struct {
+		// ImageTag is the tag of the provisioned image (e.g., "invowk-provisioned:abc123")
+		ImageTag string
+
+		// Cleanup is called to clean up temporary resources after the container exits.
+		// This may remove temporary build contexts but typically does NOT remove
+		// the cached image (for reuse). May be nil if no cleanup is needed.
+		Cleanup func()
+
+		// EnvVars are environment variables to set in the container.
+		// These configure the invowk binary and module paths inside the container.
+		EnvVars map[string]string
+	}
+)

--- a/internal/runtime/container.go
+++ b/internal/runtime/container.go
@@ -9,6 +9,7 @@ import (
 
 	"invowk-cli/internal/config"
 	"invowk-cli/internal/container"
+	"invowk-cli/internal/provision"
 	"invowk-cli/internal/sshserver"
 )
 
@@ -31,7 +32,7 @@ type (
 	ContainerRuntime struct {
 		engine      container.Engine
 		sshServer   *sshserver.Server
-		provisioner *LayerProvisioner
+		provisioner *provision.LayerProvisioner
 		cfg         *config.Config
 		envBuilder  EnvBuilder
 	}
@@ -66,7 +67,7 @@ func NewContainerRuntime(cfg *config.Config, opts ...ContainerRuntimeOption) (*C
 
 	// Create provisioner with config
 	provisionCfg := buildProvisionConfig(cfg)
-	provisioner := NewLayerProvisioner(engine, provisionCfg)
+	provisioner := provision.NewLayerProvisioner(engine, provisionCfg)
 
 	r := &ContainerRuntime{
 		engine:      engine,
@@ -82,10 +83,10 @@ func NewContainerRuntime(cfg *config.Config, opts ...ContainerRuntimeOption) (*C
 
 // NewContainerRuntimeWithEngine creates a container runtime with a specific engine.
 func NewContainerRuntimeWithEngine(engine container.Engine, opts ...ContainerRuntimeOption) *ContainerRuntime {
-	provisionCfg := DefaultProvisionConfig()
+	provisionCfg := provision.DefaultConfig()
 	r := &ContainerRuntime{
 		engine:      engine,
-		provisioner: NewLayerProvisioner(engine, provisionCfg),
+		provisioner: provision.NewLayerProvisioner(engine, provisionCfg),
 		envBuilder:  NewDefaultEnvBuilder(),
 	}
 	for _, opt := range opts {
@@ -96,9 +97,9 @@ func NewContainerRuntimeWithEngine(engine container.Engine, opts ...ContainerRun
 
 // SetProvisionConfig updates the provisioner configuration.
 // This is useful for setting the invkfile path before execution.
-func (r *ContainerRuntime) SetProvisionConfig(cfg *ContainerProvisionConfig) {
+func (r *ContainerRuntime) SetProvisionConfig(cfg *provision.Config) {
 	if cfg != nil {
-		r.provisioner = NewLayerProvisioner(r.engine, cfg)
+		r.provisioner = provision.NewLayerProvisioner(r.engine, cfg)
 	}
 }
 

--- a/internal/runtime/container_test.go
+++ b/internal/runtime/container_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"invowk-cli/internal/container"
+	"invowk-cli/internal/provision"
 	"invowk-cli/pkg/invkfile"
 )
 
@@ -521,7 +522,7 @@ func TestContainerRuntime_SetProvisionConfig(t *testing.T) {
 	initialProvisioner := rt.provisioner
 
 	// Set new config
-	newCfg := &ContainerProvisionConfig{
+	newCfg := &provision.Config{
 		Enabled:          true,
 		InvowkBinaryPath: "/custom/invowk",
 		BinaryMountPath:  "/opt/invowk",
@@ -562,13 +563,13 @@ func TestContainerRuntime_SupportsInteractive(t *testing.T) {
 
 // TestDefaultProvisionConfig_Defaults tests the default provisioning configuration values.
 func TestDefaultProvisionConfig_Defaults(t *testing.T) {
-	cfg := DefaultProvisionConfig()
+	cfg := provision.DefaultConfig()
 
 	if cfg == nil {
-		t.Fatal("DefaultProvisionConfig() returned nil")
+		t.Fatal("DefaultConfig() returned nil")
 	}
 
-	// Check defaults - values from provision.go
+	// Check defaults - values from provision package
 	if cfg.BinaryMountPath != "/invowk/bin" {
 		t.Errorf("BinaryMountPath = %q, want %q", cfg.BinaryMountPath, "/invowk/bin")
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -94,6 +94,8 @@ type (
 		WorkDir string
 		// Verbose enables verbose output
 		Verbose bool
+		// ForceRebuild forces container image rebuilds, bypassing cache (container runtime only)
+		ForceRebuild bool
 		// ExecutionID is a unique identifier for this command execution.
 		ExecutionID string
 


### PR DESCRIPTION
## Summary

- Create new `internal/provision/` package for container provisioning logic
- Add `Provisioner` interface and `LayerProvisioner` implementation  
- Add `Config` type with `ForceRebuild` field and functional options
- Export helper functions (`CalculateFileHash`, `CalculateDirHash`, `DiscoverModules`, `CopyFile`, `CopyDir`)
- Add `--force-rebuild` CLI flag to bypass image caching (container runtime only)
- Wire `ForceRebuild` through `ExecutionContext` to provisioner
- Resolve TODO in `ensureImage()` for force rebuild option

Closes #16

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes (full test suite)
- [x] `make license-check` passes
- [x] `make tidy` passes
- [ ] Manual test: `invowk cmd <container-cmd>` works
- [ ] Manual test: `invowk cmd <container-cmd> --force-rebuild` rebuilds layers

🤖 Generated with [Claude Code](https://claude.ai/code)