### PR TITLE
docs: add package documentation for container, runtime, discovery (#18)

### DIFF
--- a/.claude/rules/go-patterns.md
+++ b/.claude/rules/go-patterns.md
@@ -151,6 +151,46 @@ type Config struct {
 func Load() (*Config, error) { ... }
 ```
 
+### Package Documentation (doc.go files)
+
+For packages with extensive documentation, use a dedicated `doc.go` file:
+
+**When to use `doc.go`:**
+- Package has complex APIs requiring multi-paragraph explanation
+- Need to document architectural decisions or design rationale
+- Package has multiple concerns that should be explained together
+
+**Structure:**
+```go
+// SPDX-License-Identifier: MPL-2.0
+
+// Package name provides brief summary.
+//
+// Extended description with multiple paragraphs explaining:
+//   - Purpose and key abstractions
+//   - Important types and interfaces
+//   - Design decisions or limitations
+//   - File organization (if package spans multiple files)
+package name
+```
+
+**CRITICAL: Only one package comment per package.** When using `doc.go`, remove `// Package name ...` comments from other files (keep only `package name`). Go's `go doc` tool concatenates all package comments, causing duplicate documentation.
+
+```go
+// doc.go - Has the package documentation
+// Package config handles application configuration.
+package config
+
+// config.go - NO package comment, just package declaration
+package config
+```
+
+### Existing doc.go Examples
+
+- `internal/tui/doc.go` (9 lines): Brief, single paragraph
+- `pkg/invkfile/doc.go` (12 lines): Detailed with internal references
+- `internal/discovery/doc.go`: Multi-concern package with file organization
+
 ## Struct Tags
 
 Use JSON tags with snake_case, add mapstructure tags when using Viper:
@@ -328,3 +368,4 @@ setting-name = "value"  # Brief explanation of what this controls
 - **Silent close errors** - Use named returns with defer for resource cleanup.
 - **Missing defaults documentation** - Document default values in functional options.
 - **Wrong declaration order** - Follow const → var → type → func, exported before unexported.
+- **Duplicate package comments** - Use `doc.go` for package docs, remove `// Package` comments from other files.

--- a/internal/container/doc.go
+++ b/internal/container/doc.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package container provides a unified abstraction layer for container engines (Docker/Podman).
+//
+// The Engine interface defines the core operations: Build, Run, Remove, ImageExists, and RemoveImage.
+// Two implementations are provided: DockerEngine and PodmanEngine, both embedding BaseCLIEngine
+// for shared CLI argument construction and command execution.
+//
+// Engine selection uses NewEngine(EngineType) with automatic fallback if the preferred engine
+// is unavailable, or AutoDetectEngine() for preference-less detection (Podman is tried first).
+//
+// IMPORTANT: Only Linux containers are supported. Alpine-based images are not supported due to
+// musl compatibility issues, and Windows container images are not supported. Use debian:stable-slim
+// as the reference container image in tests and examples.
+package container

--- a/internal/container/engine.go
+++ b/internal/container/engine.go
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-// Package container provides an abstraction layer for container runtimes (Docker/Podman).
 package container
 
 import (

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,19 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-// Package discovery handles invkfile and invkmod discovery and command aggregation.
-//
-// This package intentionally combines two related concerns:
-//   - File discovery: locating invkfile.cue and invkmod directories
-//   - Command aggregation: building the unified command tree from discovered files
-//
-// These concerns are tightly coupled because command aggregation depends directly
-// on discovery results and ordering. Splitting them would create unnecessary
-// indirection without meaningful abstraction benefit.
-//
-// File organization:
-//   - discovery.go: Core types (Discovery, ModuleCollisionError) and loading methods
-//   - discovery_files.go: File discovery (DiscoverAll, discoverInDir, etc.)
-//   - discovery_commands.go: Command aggregation (DiscoverCommands, CommandInfo, etc.)
 package discovery
 
 import (

--- a/internal/discovery/doc.go
+++ b/internal/discovery/doc.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package discovery handles invkfile and invkmod discovery and command aggregation.
+//
+// This package intentionally combines two related concerns:
+//   - File discovery: locating invkfile.cue and invkmod directories
+//   - Command aggregation: building the unified command tree from discovered files
+//
+// These concerns are tightly coupled because command aggregation depends directly
+// on discovery results and ordering. Splitting them would create unnecessary
+// indirection without meaningful abstraction benefit.
+//
+// File organization:
+//   - discovery.go: Core types (Discovery, ModuleCollisionError) and loading methods
+//   - discovery_files.go: File discovery (DiscoverAll, discoverInDir, etc.)
+//   - discovery_commands.go: Command aggregation (DiscoverCommands, CommandInfo, etc.)
+//
+// Discovery follows a precedence order:
+//  1. Current directory invkfile.cue (highest)
+//  2. Modules in current directory (*.invkmod)
+//  3. User commands directory (~/.invowk/cmds)
+//  4. Configured search paths
+//
+// For command aggregation, local invkfile commands take highest precedence. Commands from
+// sibling modules are included with conflict detection when names collide across sources.
+// The DiscoveredCommandSet type provides indexed access for efficient conflict detection
+// and grouped listing.
+package discovery

--- a/internal/runtime/doc.go
+++ b/internal/runtime/doc.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package runtime provides command execution runtimes for Invowk.
+//
+// Three runtime implementations are available:
+//   - native: executes commands using the host shell (bash/sh/PowerShell)
+//   - virtual: executes commands using an embedded shell interpreter (mvdan/sh)
+//   - container: executes commands inside a container (Docker/Podman)
+//
+// All runtimes implement the Runtime interface with Name(), Execute(), Available(), and Validate().
+// Runtimes supporting output capture implement CapturingRuntime, and those supporting interactive
+// mode with PTY attachment implement InteractiveRuntime.
+//
+// ExecutionContext is the primary data structure for command execution, using composition of
+// IOContext (I/O streams), EnvContext (environment configuration), and TUIContext (TUI server).
+//
+// Environment variable building follows a 10-level precedence hierarchy managed by EnvBuilder.
+// See env_builder.go for the full precedence order, from host environment (lowest) to
+// --env-var CLI flags (highest).
+package runtime

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-// Package runtime provides the command execution runtime interface and implementations.
 package runtime
 
 import (


### PR DESCRIPTION
## Summary

- Create `doc.go` files for `internal/container`, `internal/runtime`, and `internal/discovery` packages
- Remove duplicate `// Package` comments from main source files to avoid documentation concatenation issues
- Add doc.go patterns to `.claude/rules/go-patterns.md` codifying when and how to use dedicated package documentation files
- Add "Duplicate package comments" pitfall to Common Pitfalls section

Closes #18

## Test plan

- [ ] Verify `go doc ./internal/container` displays package documentation correctly
- [ ] Verify `go doc ./internal/runtime` displays package documentation correctly
- [ ] Verify `go doc ./internal/discovery` displays package documentation correctly
- [ ] Run `make lint` to confirm no linting issues
- [ ] Run `make test` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)