### PR TITLE
fix(config,runtime): resolve existing TODOs (#19)

### DIFF
--- a/cmd/invowk/root.go
+++ b/cmd/invowk/root.go
@@ -104,8 +104,10 @@ func Execute() {
 
 // initRootConfig reads in config file and ENV variables if set.
 func initRootConfig() {
-	// TODO: Support custom config file path via cfgFile flag
-	_ = cfgFile // Currently unused; custom config file support planned
+	// Set custom config file path if provided via --config flag
+	if cfgFile != "" {
+		config.SetConfigFilePathOverride(cfgFile)
+	}
 
 	// Load configuration
 	cfg, err := config.Load()

--- a/internal/runtime/container_provision.go
+++ b/internal/runtime/container_provision.go
@@ -101,6 +101,7 @@ func (r *ContainerRuntime) ensureImage(ctx *ExecutionContext, cfg invkfileContai
 		ContextDir: invowkDir,
 		Dockerfile: containerfile,
 		Tag:        imageTag,
+		NoCache:    ctx.ForceRebuild,
 		Stdout:     ctx.IO.Stdout,
 		Stderr:     ctx.IO.Stderr,
 	}


### PR DESCRIPTION
## Summary

Resolves #19 by implementing two existing TODOs in the codebase:

- **Custom Config File Path (`--config` flag)**: The `--config` flag now works, allowing users to load configuration from a custom file path. When the specified file doesn't exist, an ActionableError is returned with helpful suggestions.

- **Force Rebuild NoCache (`--force-rebuild` flag)**: The `--force-rebuild` flag now passes `--no-cache` to Docker/Podman build commands, ensuring a complete rebuild without using cached layers.

## Changes

| File | Changes |
|------|---------|
| `cmd/invowk/root.go` | Wire up `cfgFile` to `config.SetConfigFilePathOverride()` |
| `internal/config/config.go` | Add `configFilePathOverride` variable, `SetConfigFilePathOverride()` function, modify `Load()` and `Reset()` |
| `internal/config/config_test.go` | Add 6 new tests for custom config path functionality |
| `internal/runtime/container_provision.go` | Add `NoCache: ctx.ForceRebuild` to BuildOptions |

## Test plan

- [x] `make test` passes (full test suite)
- [x] `make lint` passes
- [x] `make license-check` passes
- [x] `make tidy` passes
- [x] New tests added for custom config path functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)