### PR TITLE
ci(benchmarks): run Bencher on bare metal

### DIFF
--- a/.agents/skills/bencher/SKILL.md
+++ b/.agents/skills/bencher/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: bencher
+description: Maintain and troubleshoot Invowk's Bencher benchmark infrastructure. Use when working on Bencher, BMF benchmark output, benchmark GitHub Actions, dedicated/bare-metal runner handoff, benchmark image packaging, Bencher thresholds, "No thresholds found" dashboard warnings, benchmark alerts, or files such as `.github/workflows/benchmarks*.yml`, `scripts/bench-bmf.mjs`, `scripts/bencher-threshold-args.sh`, `scripts/bencher-registry-login.sh`, and `build/bencher/Dockerfile`.
+---
+
+# Bencher
+
+## Overview
+
+Use this skill to keep Invowk's Bencher integration coherent: GitHub Actions packages the benchmark image, Bencher runs the measurement job on the configured Spec/Testbed, and BMF output plus thresholds determine the dashboard, alerts, and PR status.
+
+## Source Files
+
+- `.github/workflows/benchmarks.yml`: base-repo PR and `main` benchmark flow.
+- `.github/workflows/benchmarks-upload.yml`: trusted workflow for fork PR benchmark upload.
+- `build/bencher/Dockerfile`: reproducible benchmark image, Go/Node versions, vendoring, warmup.
+- `scripts/bench-bmf.mjs`: emits BMF JSON and controls the public tracked suite through `TRACKED_GO_BENCHMARKS` and `SHORT_BENCH_REGEX`.
+- `scripts/bencher-threshold-args.sh`: defines every threshold model passed to `bencher run`.
+- `scripts/bencher-registry-login.sh`: derives the Docker registry user from the Bencher JWT `sub` claim.
+- Benchmark workloads currently come from `internal/benchmark`, `internal/app/modulesync`, `internal/app/moduleops`, and `cmd/invowk`.
+
+## Runner Model
+
+- Preserve the dedicated Bencher runner design. GitHub Actions should package and push the benchmark image only; it must not measure benchmarks on GitHub-hosted runners.
+- Keep `BENCHER_SPEC` and `BENCHER_TESTBED` in sync across both benchmark workflows. Current values are `intel-v1` and `bencher-intel-v1-go-1-26`.
+- For base-repo PRs, use branch `pr-<number>`, hash the PR head SHA, and pass the base branch and base SHA as the start point.
+- For PR branches, keep `--start-point-clone-thresholds` and `--start-point-reset` so PR history is anchored to the base branch.
+- For fork PRs, use the trusted upload workflow: checkout trusted packaging separately from untrusted source, build the image with trusted workflow/scripts, then ask Bencher to run the source image.
+
+## Threshold Model
+
+- Treat thresholds as linked to `branch + testbed + measure`, not to individual benchmarks.
+- Use measure slugs as the stable identifiers in `--threshold-measure`. Bencher may display title-cased names such as `Latency`, `File Size`, and `Build Time`, while their slugs are `latency`, `file-size`, and `build-time`.
+- If `scripts/bench-bmf.mjs` emits a new measure and alerts are expected, add the matching threshold model in `scripts/bencher-threshold-args.sh` in the same patch.
+- If `scripts/bench-bmf.mjs` adds only new benchmarks using existing measures, no new threshold is needed.
+- Keep `--thresholds-reset` so stale threshold models do not survive after measures are removed or renamed.
+- Use upper-bound-only thresholds for regressions. Lower values are improvements for latency, memory, allocations, build time, and file size.
+
+Current emitted measures and threshold defaults:
+
+| Measure slug | Display name | Threshold |
+|--------------|--------------|-----------|
+| `latency` | `Latency` | percentage, min sample 5, max sample 64, upper `0.10` |
+| `memory` | `memory` | percentage, min sample 5, max sample 64, upper `0.10` |
+| `allocations` | `allocations` | percentage, min sample 5, max sample 64, upper `0.10` |
+| `build-time` | `Build Time` | percentage, min sample 5, max sample 32, upper `0.20` |
+| `file-size` | `File Size` | percentage, min sample 2, max sample 16, upper `0.10` |
+
+## Diagnostics
+
+When the dashboard says `No thresholds found`, check the report JSON first. A successful `bencher run` can still have one unthresholded measure.
+
+```bash
+project=ddfe58db-e86d-49b8-a6c7-60fc46eabf0b
+branch=pr-112
+testbed=bencher-intel-v1-go-1-26
+api=https://api.bencher.dev/v0
+curl -fsS "$api/projects/$project/reports?branch=$branch&testbed=$testbed&sort=date_time&direction=desc&per_page=1" |
+	jq -r '.[0].results[][] as $bench |
+		$bench.measures[] |
+		select(.threshold == null) |
+		[$bench.benchmark.name, .measure.slug, .measure.name, .metric.value] |
+		@tsv'
+```
+
+Summarize threshold coverage by measure:
+
+```bash
+curl -fsS "$api/projects/$project/reports?branch=$branch&testbed=$testbed&sort=date_time&direction=desc&per_page=1" |
+	jq -r '[.[0].results[][] as $bench |
+		$bench.measures[] |
+		{measure:.measure.slug, has_threshold:(.threshold != null)}] |
+		group_by(.measure)[] |
+		[.[0].measure, length, (map(select(.has_threshold)) | length), (map(select(.has_threshold | not)) | length)] |
+		@tsv'
+```
+
+List the active threshold models:
+
+```bash
+curl -fsS "$api/projects/$project/thresholds?branch=$branch&testbed=$testbed" |
+	jq -r '.[] |
+		[.measure.slug, .measure.name, .model.test, .model.upper_boundary, .model.min_sample_size, .model.max_sample_size] |
+		@tsv' |
+	sort
+```
+
+Inspect Actions logs for the actual `bencher run` request and report URL:
+
+```bash
+gh run view <run-id> --repo invowk/invowk --log > /tmp/bencher.log
+rg -n 'Bencher New Report|thresholds|View report|No thresholds|Job status|BENCHER_|--threshold|--start-point' /tmp/bencher.log
+```
+
+## Known Pitfalls
+
+- `latency` versus `Latency` is not a threshold bug by itself. In PR 112, the slug `latency` correctly matched the displayed `Latency`; the warning came from missing `build-time`.
+- `boundary.baseline: null` usually means the threshold exists but Bencher does not yet have enough samples for that model. This is different from `threshold: null`.
+- A Bencher JWT or registry failure often looks like broken benchmark code. Check `BENCHER_API_TOKEN`, the registry login script, and direct API access before rewriting benchmark logic.
+- Context7 may resolve `Bencher` to unrelated benchmark projects. When that happens, use official Bencher docs plus direct API, CLI output, and report JSON as the source of truth.
+- Do not treat `SHORT_BENCH_REGEX` as internal cleanup. It controls what becomes long-lived public benchmark history.
+
+## Verification
+
+After Bencher infrastructure changes:
+
+- Run focused script checks such as `bash -n scripts/bencher-threshold-args.sh`.
+- If BMF output changed, run the Node tests or the BMF script tests in CI.
+- Push and watch the `Benchmarks / Track Benchmarks` check.
+- Verify the latest Bencher report has zero `threshold: null` measures if the task involved thresholds.
+- Check PR status with `gh pr view <number> --json mergeStateStatus,mergeable,statusCheckRollup`.

--- a/.agents/skills/bencher/agents/openai.yaml
+++ b/.agents/skills/bencher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bencher"
+  short_description: "Maintain Invowk Bencher benchmarks"
+  default_prompt: "Use $bencher to diagnose Invowk benchmark CI or threshold issues."

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,6 +92,7 @@ Commands are user-invokable slash commands (e.g., `/review-docs`) that execute m
 
 Skills provide domain-specific procedural guidance. They are invoked when working on specific components.
 
+- [`.agents/skills/bencher/`](.agents/skills/bencher/) - Bencher benchmark CI, BMF output, dedicated runner handoff, thresholds, reports, and alert troubleshooting.
 - [`.agents/skills/cli/`](.agents/skills/cli/) - CLI command structure, Cobra patterns, execution flow, hidden internal commands.
 - [`.agents/skills/container/`](.agents/skills/container/) - Container engine abstraction, Docker/Podman patterns, path handling, Linux-only policy.
 - [`.agents/skills/cue/`](.agents/skills/cue/) - CUE schema parsing, 3-step parse flow, validation matrix, schema sync tests.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MPL-2.0
+
+.git
+.github
+.codex
+.claude
+.agents
+artifacts
+bin
+coverage
+dist
+node_modules
+tmp
+*.out
+*.prof

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,6 @@ coverage
 dist
 node_modules
 tmp
+vendor
 *.out
 *.prof

--- a/.github/workflows/benchmarks-upload.yml
+++ b/.github/workflows/benchmarks-upload.yml
@@ -13,16 +13,21 @@ concurrency:
 
 env:
   BENCHER_PROJECT: ddfe58db-e86d-49b8-a6c7-60fc46eabf0b
-  BENCHER_TESTBED: github-ubuntu-24-04-go-1-26
+  BENCHER_TESTBED: bencher-intel-v1-go-1-26
+  BENCHER_SPEC: intel-v1
+  BENCHER_IMAGE_REPOSITORY: registry.bencher.dev/invowk
+  BENCHER_JOB_TIMEOUT: 1800
+  BENCH_BMF_OUT: /tmp/invowk.bmf.json
+  BENCH_GO_RAW_OUT: /tmp/go-bench.txt
 
 jobs:
   upload-fork-pr:
     name: Upload Fork PR Benchmarks
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
-    # GitHub-hosted Ubuntu 26.04 is not available yet. This upload job does
-    # not run benchmarks, but it shares the same pinned support boundary.
+    # GitHub Actions only packages the benchmark image. Bencher runs the actual
+    # benchmarks on the bare-metal Spec configured above.
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -56,25 +61,40 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "branch=pr-$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head-repo=$head_repo" >> "$GITHUB_OUTPUT"
           echo "head-sha=$(jq -r '.head.sha' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
           echo "base-ref=$(jq -r '.base.ref' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
           echo "base-sha=$(jq -r '.base.sha' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
           echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Download benchmark artifact
+      - name: Checkout trusted benchmark packaging
         if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          path: trusted
+
+      - name: Checkout pull request head
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.pr.outputs.head-repo }}
+          ref: ${{ steps.pr.outputs.head-sha }}
+          path: source
+
+      - name: Build and push benchmark image
+        if: steps.pr.outputs.skip != 'true'
+        id: image
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ steps.pr.outputs.run-id }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BENCHER_IMAGE_TAG: ${{ steps.pr.outputs.head-sha }}
         run: |
           set -euo pipefail
-          mkdir -p artifacts/benchmarks-import
-          gh run download "$RUN_ID" \
-            --name "bench-bmf-pr-$PR_NUMBER" \
-            --dir artifacts/benchmarks-import
-          test -s artifacts/benchmarks-import/invowk.bmf.json
+
+          cp trusted/.dockerignore source/.dockerignore
+          image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
+          docker build --platform linux/amd64 -f trusted/build/bencher/Dockerfile -t "$image" source
+          docker push "$image"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
 
       - name: Install Bencher CLI
         if: steps.pr.outputs.skip != 'true'
@@ -91,8 +111,13 @@ jobs:
           BENCHER_HASH: ${{ steps.pr.outputs.head-sha }}
           BENCHER_START_POINT: ${{ steps.pr.outputs.base-ref }}
           BENCHER_START_POINT_HASH: ${{ steps.pr.outputs.base-sha }}
+          BENCHER_IMAGE: ${{ steps.image.outputs.image }}
         run: |
           set -euo pipefail
+          source trusted/scripts/bencher-threshold-args.sh
+
+          threshold_args=()
+          bencher_threshold_args threshold_args
 
           bencher run \
             --project "$BENCHER_PROJECT" \
@@ -103,9 +128,15 @@ jobs:
             --start-point-clone-thresholds \
             --start-point-reset \
             --testbed "$BENCHER_TESTBED" \
+            --spec "$BENCHER_SPEC" \
+            --image "$BENCHER_IMAGE" \
+            --job-timeout "$BENCHER_JOB_TIMEOUT" \
+            --job-poll-interval 5 \
             --adapter json \
-            --file artifacts/benchmarks-import/invowk.bmf.json \
+            --file "$BENCH_BMF_OUT" \
             --github-actions "$GITHUB_TOKEN" \
             --ci-id bmf \
             --ci-number "$PR_NUMBER" \
-            --error-on-alert
+            "${threshold_args[@]}" \
+            --error-on-alert \
+            "node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"

--- a/.github/workflows/benchmarks-upload.yml
+++ b/.github/workflows/benchmarks-upload.yml
@@ -87,15 +87,15 @@ jobs:
         shell: bash
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
           BENCHER_IMAGE_TAG: ${{ steps.pr.outputs.head-sha }}
         run: |
           set -euo pipefail
+          source trusted/scripts/bencher-registry-login.sh
 
           cp trusted/.dockerignore source/.dockerignore
           image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
           docker build --platform linux/amd64 -f trusted/build/bencher/Dockerfile -t "$image" source
-          echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$BENCHER_USER_EMAIL" --password-stdin
+          bencher_registry_login
           docker push "$image"
           echo "image=$image" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/benchmarks-upload.yml
+++ b/.github/workflows/benchmarks-upload.yml
@@ -86,6 +86,8 @@ jobs:
         id: image
         shell: bash
         env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
           BENCHER_IMAGE_TAG: ${{ steps.pr.outputs.head-sha }}
         run: |
           set -euo pipefail
@@ -93,6 +95,7 @@ jobs:
           cp trusted/.dockerignore source/.dockerignore
           image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
           docker build --platform linux/amd64 -f trusted/build/bencher/Dockerfile -t "$image" source
+          echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$BENCHER_USER_EMAIL" --password-stdin
           docker push "$image"
           echo "image=$image" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/benchmarks-upload.yml
+++ b/.github/workflows/benchmarks-upload.yml
@@ -142,4 +142,4 @@ jobs:
             --ci-number "$PR_NUMBER" \
             "${threshold_args[@]}" \
             --error-on-alert \
-            "GOPROXY=off GOSUMDB=off node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
+            "GOPROXY=off GOSUMDB=off GOFLAGS=-mod=vendor node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"

--- a/.github/workflows/benchmarks-upload.yml
+++ b/.github/workflows/benchmarks-upload.yml
@@ -142,4 +142,4 @@ jobs:
             --ci-number "$PR_NUMBER" \
             "${threshold_args[@]}" \
             --error-on-alert \
-            "node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
+            "GOPROXY=off GOSUMDB=off node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -135,7 +135,7 @@ jobs:
             "${threshold_args[@]}" \
             --error-on-alert \
             "${start_point_args[@]}" \
-            "GOPROXY=off GOSUMDB=off node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
+            "GOPROXY=off GOSUMDB=off GOFLAGS=-mod=vendor node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
 
   fork-pr-artifact:
     name: Benchmark Fork PR

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -135,7 +135,7 @@ jobs:
             "${threshold_args[@]}" \
             --error-on-alert \
             "${start_point_args[@]}" \
-            "node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
+            "GOPROXY=off GOSUMDB=off node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
 
   fork-pr-artifact:
     name: Benchmark Fork PR

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -80,12 +80,15 @@ jobs:
         id: image
         shell: bash
         env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
           BENCHER_IMAGE_TAG: ${{ steps.meta.outputs.hash }}
         run: |
           set -euo pipefail
 
           image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
           docker build --platform linux/amd64 -f build/bencher/Dockerfile -t "$image" .
+          echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$BENCHER_USER_EMAIL" --password-stdin
           docker push "$image"
           echo "image=$image" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,15 +21,19 @@ concurrency:
 env:
   GOPROXY: "https://proxy.golang.org|direct"
   BENCHER_PROJECT: ddfe58db-e86d-49b8-a6c7-60fc46eabf0b
-  BENCHER_TESTBED: github-ubuntu-24-04-go-1-26
-  BENCH_BMF_OUT: artifacts/benchmarks/invowk.bmf.json
+  BENCHER_TESTBED: bencher-intel-v1-go-1-26
+  BENCHER_SPEC: intel-v1
+  BENCHER_IMAGE_REPOSITORY: registry.bencher.dev/invowk
+  BENCHER_JOB_TIMEOUT: 1800
+  BENCH_BMF_OUT: /tmp/invowk.bmf.json
+  BENCH_GO_RAW_OUT: /tmp/go-bench.txt
 
 jobs:
   bencher:
     name: Track Benchmarks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    # GitHub-hosted Ubuntu 26.04 is not available yet. Pin benchmark runs to
-    # the newest supported Ubuntu image and mirror that in BENCHER_TESTBED.
+    # GitHub Actions only packages the benchmark image. Bencher runs the actual
+    # benchmarks on the bare-metal Spec configured above.
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -42,30 +46,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Download Go modules
-        shell: bash
-        run: |
-          for attempt in 1 2 3; do
-            if go mod download; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep "$((attempt * 20))"
-          done
 
       - name: Install Bencher CLI
         uses: bencherdev/bencher@main
@@ -96,6 +76,19 @@ jobs:
             echo "start-point-hash=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build and push benchmark image
+        id: image
+        shell: bash
+        env:
+          BENCHER_IMAGE_TAG: ${{ steps.meta.outputs.hash }}
+        run: |
+          set -euo pipefail
+
+          image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
+          docker build --platform linux/amd64 -f build/bencher/Dockerfile -t "$image" .
+          docker push "$image"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
       - name: Track benchmark data in Bencher
         shell: bash
         env:
@@ -105,8 +98,10 @@ jobs:
           BENCHER_HASH: ${{ steps.meta.outputs.hash }}
           BENCHER_START_POINT: ${{ steps.meta.outputs.start-point }}
           BENCHER_START_POINT_HASH: ${{ steps.meta.outputs.start-point-hash }}
+          BENCHER_IMAGE: ${{ steps.image.outputs.image }}
         run: |
           set -euo pipefail
+          source scripts/bencher-threshold-args.sh
 
           start_point_args=()
           if [[ -n "$BENCHER_START_POINT" ]]; then
@@ -118,54 +113,36 @@ jobs:
             )
           fi
 
+          threshold_args=()
+          bencher_threshold_args threshold_args
+
           bencher run \
             --project "$BENCHER_PROJECT" \
             --branch "$BENCHER_BRANCH" \
             --hash "$BENCHER_HASH" \
             --testbed "$BENCHER_TESTBED" \
+            --spec "$BENCHER_SPEC" \
+            --image "$BENCHER_IMAGE" \
+            --job-timeout "$BENCHER_JOB_TIMEOUT" \
+            --job-poll-interval 5 \
             --adapter json \
             --file "$BENCH_BMF_OUT" \
             --github-actions "$GITHUB_TOKEN" \
             --ci-id bmf \
+            "${threshold_args[@]}" \
             --error-on-alert \
             "${start_point_args[@]}" \
-            "node scripts/bench-bmf.mjs --output artifacts/benchmarks/invowk.bmf.json --raw-go-output artifacts/benchmarks/go-bench.txt"
+            "node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
 
   fork-pr-artifact:
     name: Benchmark Fork PR
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    # See the trusted Bencher job above for the runner/testbed rationale.
+    # The trusted workflow_run handler builds the image and asks Bencher to run
+    # benchmarks on bare metal. This job only creates a successful trigger.
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:
-      - name: Checkout pull request head
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Generate BMF benchmark data
-        run: node scripts/bench-bmf.mjs --output artifacts/benchmarks/invowk.bmf.json --raw-go-output artifacts/benchmarks/go-bench.txt
-
-      - name: Upload BMF benchmark data
-        uses: actions/upload-artifact@v7
-        with:
-          name: bench-bmf-pr-${{ github.event.pull_request.number }}
-          path: |
-            artifacts/benchmarks/invowk.bmf.json
-            artifacts/benchmarks/go-bench.txt
-          if-no-files-found: error
-          retention-days: 7
+      - name: Defer fork PR benchmarks to trusted bare-metal workflow
+        run: echo "Fork PR benchmark execution is handled by benchmarks-upload.yml on Bencher bare metal."

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -81,14 +81,14 @@ jobs:
         shell: bash
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
           BENCHER_IMAGE_TAG: ${{ steps.meta.outputs.hash }}
         run: |
           set -euo pipefail
+          source scripts/bencher-registry-login.sh
 
           image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
           docker build --platform linux/amd64 -f build/bencher/Dockerfile -t "$image" .
-          echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$BENCHER_USER_EMAIL" --password-stdin
+          bencher_registry_login
           docker push "$image"
           echo "image=$image" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,11 @@ jobs:
         shell: bash
         run: node scripts/test_bench_bmf.mjs
 
+      - name: Run Bencher registry login script tests
+        if: startsWith(matrix.runner, 'ubuntu')
+        shell: bash
+        run: bash scripts/test_bencher_registry_login.sh
+
       # Run PowerShell install script tests (PS 7.x/Core).
       - name: Run PowerShell install script tests (pwsh)
         if: matrix.os == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,7 +506,7 @@ jobs:
             --error-on-alert \
             "${start_point_args[@]}" \
             "${dry_run_args[@]}" \
-            "node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
+            "GOPROXY=off GOSUMDB=off node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
 
       # Run GoReleaser (publish)
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,7 +506,7 @@ jobs:
             --error-on-alert \
             "${start_point_args[@]}" \
             "${dry_run_args[@]}" \
-            "GOPROXY=off GOSUMDB=off node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
+            "GOPROXY=off GOSUMDB=off GOFLAGS=-mod=vendor node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
 
       # Run GoReleaser (publish)
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,8 @@ jobs:
         id: bench-image
         shell: bash
         env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
           BENCHER_IMAGE_REPOSITORY: registry.bencher.dev/invowk
           BENCHER_IMAGE_TAG: ${{ steps.bench-meta.outputs.release-sha }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
@@ -438,6 +440,7 @@ jobs:
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "Dry run requested; skipping benchmark image push."
           else
+            echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$BENCHER_USER_EMAIL" --password-stdin
             docker push "$image"
           fi
           echo "image=$image" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,11 @@ jobs:
         shell: bash
         run: node scripts/test_bench_bmf.mjs
 
+      - name: Run Bencher registry login script tests
+        if: startsWith(matrix.runner, 'ubuntu')
+        shell: bash
+        run: bash scripts/test_bencher_registry_login.sh
+
       # Run WinGet manifest enhancement tests (Python + bash, no network calls).
       - name: Run WinGet enhancement tests
         if: startsWith(matrix.runner, 'ubuntu')
@@ -428,19 +433,19 @@ jobs:
         shell: bash
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_USER_EMAIL: ${{ secrets.BENCHER_USER_EMAIL }}
           BENCHER_IMAGE_REPOSITORY: registry.bencher.dev/invowk
           BENCHER_IMAGE_TAG: ${{ steps.bench-meta.outputs.release-sha }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
         run: |
           set -euo pipefail
+          source scripts/bencher-registry-login.sh
 
           image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
           docker build --platform linux/amd64 -f build/bencher/Dockerfile -t "$image" .
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "Dry run requested; skipping benchmark image push."
           else
-            echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$BENCHER_USER_EMAIL" --password-stdin
+            bencher_registry_login
             docker push "$image"
           fi
           echo "image=$image" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,8 +308,8 @@ jobs:
     name: Release
     needs: [validate, test]
     if: always() && needs.test.result == 'success' && (needs.validate.result == 'success' || needs.validate.result == 'skipped')
-    # GitHub-hosted Ubuntu 26.04 is not available yet. Pin the release
-    # benchmark runner and Bencher testbed to the newest supported Ubuntu image.
+    # GitHub Actions only packages the benchmark image. Bencher runs release
+    # benchmarks on the bare-metal Spec configured below.
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -423,13 +423,36 @@ jobs:
       - name: Install Bencher CLI
         uses: bencherdev/bencher@main
 
+      - name: Build and push benchmark image
+        id: bench-image
+        shell: bash
+        env:
+          BENCHER_IMAGE_REPOSITORY: registry.bencher.dev/invowk
+          BENCHER_IMAGE_TAG: ${{ steps.bench-meta.outputs.release-sha }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        run: |
+          set -euo pipefail
+
+          image="$BENCHER_IMAGE_REPOSITORY:$BENCHER_IMAGE_TAG"
+          docker build --platform linux/amd64 -f build/bencher/Dockerfile -t "$image" .
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run requested; skipping benchmark image push."
+          else
+            docker push "$image"
+          fi
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
       - name: Track release performance in Bencher
         shell: bash
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
           BENCHER_PROJECT: ddfe58db-e86d-49b8-a6c7-60fc46eabf0b
-          BENCHER_TESTBED: github-ubuntu-24-04-go-1-26
-          BENCH_BMF_OUT: artifacts/benchmarks/invowk.bmf.json
+          BENCHER_TESTBED: bencher-intel-v1-go-1-26
+          BENCHER_SPEC: intel-v1
+          BENCHER_IMAGE: ${{ steps.bench-image.outputs.image }}
+          BENCHER_JOB_TIMEOUT: 1800
+          BENCH_BMF_OUT: /tmp/invowk.bmf.json
+          BENCH_GO_RAW_OUT: /tmp/go-bench.txt
           GITHUB_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.tag.outputs.name }}
           RELEASE_SHA: ${{ steps.bench-meta.outputs.release-sha }}
@@ -438,6 +461,7 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
         run: |
           set -euo pipefail
+          source scripts/bencher-threshold-args.sh
 
           start_point_args=()
           if [[ -n "$PREVIOUS_TAG" ]]; then
@@ -454,19 +478,27 @@ jobs:
             dry_run_args=(--dry-run)
           fi
 
+          threshold_args=()
+          bencher_threshold_args threshold_args
+
           bencher run \
             --project "$BENCHER_PROJECT" \
             --branch "$TAG_NAME" \
             --hash "$RELEASE_SHA" \
             --testbed "$BENCHER_TESTBED" \
+            --spec "$BENCHER_SPEC" \
+            --image "$BENCHER_IMAGE" \
+            --job-timeout "$BENCHER_JOB_TIMEOUT" \
+            --job-poll-interval 5 \
             --adapter json \
             --file "$BENCH_BMF_OUT" \
             --github-actions "$GITHUB_TOKEN" \
             --ci-id release-bmf \
+            "${threshold_args[@]}" \
             --error-on-alert \
             "${start_point_args[@]}" \
             "${dry_run_args[@]}" \
-            "node scripts/bench-bmf.mjs --output artifacts/benchmarks/invowk.bmf.json --raw-go-output artifacts/benchmarks/go-bench.txt"
+            "node scripts/bench-bmf.mjs --output '$BENCH_BMF_OUT' --raw-go-output '$BENCH_GO_RAW_OUT'"
 
       # Run GoReleaser (publish)
       - name: Run GoReleaser

--- a/build/bencher/Dockerfile
+++ b/build/bencher/Dockerfile
@@ -9,8 +9,7 @@ COPY --from=go-base /usr/local/go /usr/local/go
 
 ENV PATH="/usr/local/go/bin:${PATH}" \
     GOPATH="/go" \
-    GOMODCACHE="/go/pkg/mod" \
-    GOCACHE="/go/build-cache" \
+    GOCACHE="/tmp/go-build-cache" \
     GOAMD64="v3" \
     GOTOOLCHAIN=local \
     GOPROXY="https://proxy.golang.org|direct"
@@ -27,19 +26,18 @@ RUN apt-get update \
 
 WORKDIR /workspace
 
-RUN mkdir -p "${GOMODCACHE}" "${GOCACHE}" "${GOPATH}/bin" \
+RUN mkdir -p "${GOCACHE}" "${GOPATH}/bin" \
     && chmod -R a+rwX "${GOPATH}"
-
-COPY go.mod go.sum ./
-RUN go mod download all
 
 COPY . .
 ENV GOPROXY="off" \
-    GOSUMDB="off"
+    GOSUMDB="off" \
+    GOFLAGS="-mod=vendor"
 
-RUN go build -trimpath -o /tmp/invowk-warmup . \
+RUN GOPROXY="https://proxy.golang.org|direct" GOSUMDB="sum.golang.org" GOFLAGS="" go mod vendor \
+    && go build -trimpath -o /tmp/invowk-warmup . \
     && go test ./internal/benchmark ./internal/app/modulesync ./internal/app/moduleops ./cmd/invowk -run=^$ -bench=^$ \
-    && rm -f /tmp/invowk-warmup \
+    && rm -rf /tmp/invowk-warmup "${GOCACHE}" \
     && chmod -R a+rwX "${GOPATH}" /workspace
 
 CMD ["node", "scripts/bench-bmf.mjs", "--output", "/tmp/invowk.bmf.json", "--raw-go-output", "/tmp/go-bench.txt"]

--- a/build/bencher/Dockerfile
+++ b/build/bencher/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: MPL-2.0
+
+FROM golang:1.26-bookworm AS go-base
+
+FROM node:24-bookworm-slim
+
+COPY --from=go-base /usr/local/go /usr/local/go
+
+ENV PATH="/usr/local/go/bin:${PATH}" \
+    GOTOOLCHAIN=local \
+    GOPROXY="https://proxy.golang.org|direct"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        gcc \
+        git \
+        libc6-dev \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+CMD ["node", "scripts/bench-bmf.mjs", "--output", "/tmp/invowk.bmf.json", "--raw-go-output", "/tmp/go-bench.txt"]

--- a/build/bencher/Dockerfile
+++ b/build/bencher/Dockerfile
@@ -8,6 +8,10 @@ FROM node:24-bookworm-slim
 COPY --from=go-base /usr/local/go /usr/local/go
 
 ENV PATH="/usr/local/go/bin:${PATH}" \
+    GOPATH="/go" \
+    GOMODCACHE="/go/pkg/mod" \
+    GOCACHE="/go/build-cache" \
+    GOAMD64="v3" \
     GOTOOLCHAIN=local \
     GOPROXY="https://proxy.golang.org|direct"
 
@@ -23,9 +27,19 @@ RUN apt-get update \
 
 WORKDIR /workspace
 
+RUN mkdir -p "${GOMODCACHE}" "${GOCACHE}" "${GOPATH}/bin" \
+    && chmod -R a+rwX "${GOPATH}"
+
 COPY go.mod go.sum ./
-RUN go mod download
+RUN go mod download all
 
 COPY . .
+ENV GOPROXY="off" \
+    GOSUMDB="off"
+
+RUN go build -trimpath -o /tmp/invowk-warmup . \
+    && go test ./internal/benchmark ./internal/app/modulesync ./internal/app/moduleops ./cmd/invowk -run=^$ -bench=^$ \
+    && rm -f /tmp/invowk-warmup \
+    && chmod -R a+rwX "${GOPATH}" /workspace
 
 CMD ["node", "scripts/bench-bmf.mjs", "--output", "/tmp/invowk.bmf.json", "--raw-go-output", "/tmp/go-bench.txt"]

--- a/scripts/bencher-registry-login.sh
+++ b/scripts/bencher-registry-login.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+
+bencher_api_token_subject() {
+	local token="${BENCHER_API_TOKEN:?BENCHER_API_TOKEN is required}"
+	local payload
+	local subject
+
+	if [[ "$token" != *.*.* ]]; then
+		echo "::error::BENCHER_API_TOKEN must be a JWT with three segments." >&2
+		return 1
+	fi
+
+	payload="${token#*.}"
+	payload="${payload%%.*}"
+	case $((${#payload} % 4)) in
+		0) ;;
+		2) payload="${payload}==" ;;
+		3) payload="${payload}=" ;;
+		*)
+			echo "::error::BENCHER_API_TOKEN has an invalid JWT payload length." >&2
+			return 1
+			;;
+	esac
+
+	if ! subject="$(printf '%s' "$payload" |
+		tr '_-' '/+' |
+		base64 -d 2>/dev/null |
+		jq -er '.sub | select(type == "string" and length > 0)' 2>/dev/null)"; then
+		echo "::error::BENCHER_API_TOKEN JWT payload must include a non-empty sub claim." >&2
+		return 1
+	fi
+
+	printf '%s\n' "$subject"
+}
+
+bencher_registry_login() {
+	local subject
+
+	subject="$(bencher_api_token_subject)"
+	echo "$BENCHER_API_TOKEN" | docker login registry.bencher.dev -u "$subject" --password-stdin
+}

--- a/scripts/bencher-threshold-args.sh
+++ b/scripts/bencher-threshold-args.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+
+bencher_threshold_args() {
+	local -n args_ref="$1"
+	args_ref=(
+		--threshold-measure latency
+		--threshold-test percentage
+		--threshold-min-sample-size 5
+		--threshold-max-sample-size 64
+		--threshold-lower-boundary _
+		--threshold-upper-boundary 0.10
+		--threshold-measure memory
+		--threshold-test percentage
+		--threshold-min-sample-size 5
+		--threshold-max-sample-size 64
+		--threshold-lower-boundary _
+		--threshold-upper-boundary 0.10
+		--threshold-measure allocations
+		--threshold-test percentage
+		--threshold-min-sample-size 5
+		--threshold-max-sample-size 64
+		--threshold-lower-boundary _
+		--threshold-upper-boundary 0.10
+		--threshold-measure file-size
+		--threshold-test percentage
+		--threshold-min-sample-size 2
+		--threshold-max-sample-size 16
+		--threshold-lower-boundary _
+		--threshold-upper-boundary 0.10
+		--thresholds-reset
+	)
+}

--- a/scripts/bencher-threshold-args.sh
+++ b/scripts/bencher-threshold-args.sh
@@ -22,6 +22,12 @@ bencher_threshold_args() {
 		--threshold-max-sample-size 64
 		--threshold-lower-boundary _
 		--threshold-upper-boundary 0.10
+		--threshold-measure build-time
+		--threshold-test percentage
+		--threshold-min-sample-size 5
+		--threshold-max-sample-size 32
+		--threshold-lower-boundary _
+		--threshold-upper-boundary 0.20
 		--threshold-measure file-size
 		--threshold-test percentage
 		--threshold-min-sample-size 2

--- a/scripts/test_bencher_registry_login.sh
+++ b/scripts/test_bencher_registry_login.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=bencher-registry-login.sh
+source "$SCRIPT_DIR/bencher-registry-login.sh"
+
+jwt_for_subject() {
+	local subject="$1"
+	local payload
+
+	payload="$(jq -cn --arg subject "$subject" '{sub: $subject}' | base64 -w0 | tr '+/' '-_' | tr -d '=')"
+	printf 'header.%s.signature\n' "$payload"
+}
+
+assert_eq() {
+	local desc="$1"
+	local expected="$2"
+	local actual="$3"
+
+	if [[ "$expected" != "$actual" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$desc" "$expected" "$actual" >&2
+		exit 1
+	fi
+}
+
+assert_rejects() {
+	local desc="$1"
+	shift
+
+	if "$@" >/dev/null 2>&1; then
+		printf 'FAIL: %s\n  command unexpectedly succeeded\n' "$desc" >&2
+		exit 1
+	fi
+}
+
+test_subject_extraction() {
+	local token
+	local subject
+
+	token="$(jwt_for_subject 'ci@example.com')"
+	subject="$(BENCHER_API_TOKEN="$token" bencher_api_token_subject)"
+	assert_eq "extracts JWT subject" "ci@example.com" "$subject"
+}
+
+test_invalid_tokens_fail() {
+	assert_rejects "rejects malformed JWT" env BENCHER_API_TOKEN="not-a-jwt" bash -c \
+		'source "$BENCHER_LOGIN_SCRIPT"; bencher_api_token_subject'
+
+	assert_rejects "rejects JWT without subject" env BENCHER_API_TOKEN="header.$(printf '{}' | base64 -w0).signature" bash -c \
+		'source "$BENCHER_LOGIN_SCRIPT"; bencher_api_token_subject'
+}
+
+test_registry_login_uses_subject() {
+	local tmp
+	local token
+	local args_file
+	local stdin_file
+	local mock_docker
+
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "$tmp"' RETURN
+	args_file="$tmp/docker.args"
+	stdin_file="$tmp/docker.stdin"
+	mock_docker="$tmp/docker"
+
+	cat >"$mock_docker" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$DOCKER_ARGS_FILE"
+cat > "$DOCKER_STDIN_FILE"
+MOCK
+	chmod +x "$mock_docker"
+
+	token="$(jwt_for_subject 'registry@example.com')"
+	DOCKER_ARGS_FILE="$args_file" \
+		DOCKER_STDIN_FILE="$stdin_file" \
+		PATH="$tmp:$PATH" \
+		BENCHER_API_TOKEN="$token" \
+		bencher_registry_login >/dev/null
+
+	assert_eq "docker login args" "login registry.bencher.dev -u registry@example.com --password-stdin" "$(cat "$args_file")"
+	assert_eq "docker login stdin" "$token" "$(cat "$stdin_file")"
+}
+
+test_subject_extraction
+export BENCHER_LOGIN_SCRIPT="$SCRIPT_DIR/bencher-registry-login.sh"
+test_invalid_tokens_fail
+test_registry_login_uses_subject
+
+echo "bencher registry login tests passed"

--- a/website/docs/performance/benchmark-history.mdx
+++ b/website/docs/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 The output is written to `artifacts/benchmarks/invowk.bmf.json` and can be uploaded with Bencher's `json` adapter.
 
-CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_USER_EMAIL` and `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules and installs runtime dependencies at image build time.
+CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules and installs runtime dependencies at image build time.

--- a/website/docs/performance/benchmark-history.mdx
+++ b/website/docs/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 The output is written to `artifacts/benchmarks/invowk.bmf.json` and can be uploaded with Bencher's `json` adapter.
 
-CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules, warms the benchmark build path, and installs runtime dependencies at image build time.
+CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image vendors Go dependencies and installs runtime dependencies at image build time.

--- a/website/docs/performance/benchmark-history.mdx
+++ b/website/docs/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 The output is written to `artifacts/benchmarks/invowk.bmf.json` and can be uploaded with Bencher's `json` adapter.
 
-CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules and installs runtime dependencies at image build time.
+CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules, warms the benchmark build path, and installs runtime dependencies at image build time.

--- a/website/docs/performance/benchmark-history.mdx
+++ b/website/docs/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 The output is written to `artifacts/benchmarks/invowk.bmf.json` and can be uploaded with Bencher's `json` adapter.
 
-CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, pushes it to Bencher's registry, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules and installs runtime dependencies at image build time.
+CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, logs in to Bencher's registry with `BENCHER_USER_EMAIL` and `BENCHER_API_TOKEN`, pushes the image, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules and installs runtime dependencies at image build time.

--- a/website/docs/performance/benchmark-history.mdx
+++ b/website/docs/performance/benchmark-history.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Invowk tracks release performance in [Bencher](https://bencher.dev/perf/invowk). The public history is keyed by release tag, so users can compare published versions such as `v0.12.0` and `v0.13.0` directly.
 
-Pull request benchmark runs are maintainer guardrails. They can fail a change when Bencher detects a regression, but they are not the user-facing performance history.
+Pull request benchmark runs are maintainer guardrails. They can fail a change when Bencher detects a regression, but they are not the user-facing performance history. Pull requests use the same Bencher bare-metal Spec as release runs.
 
 ## Release Workflow
 
@@ -16,6 +16,7 @@ The release workflow uploads Bencher Metric Format JSON before publishing the Gi
 - `--hash` is the release commit SHA.
 - `--start-point` is the previous release tag when one exists.
 - `--start-point-clone-thresholds` and `--start-point-reset` keep release thresholds and history aligned from version to version.
+- `--image` and `--spec` make Bencher execute the benchmark command on bare-metal runners, not on the GitHub Actions runner that packaged the image.
 
 ## Tracked Metrics
 
@@ -35,3 +36,5 @@ make bench-bmf
 ```
 
 The output is written to `artifacts/benchmarks/invowk.bmf.json` and can be uploaded with Bencher's `json` adapter.
+
+CI packages the benchmark source into an OCI image with `build/bencher/Dockerfile`, pushes it to Bencher's registry, and then calls `bencher run --image ... --spec ...`. Shared Bencher bare-metal runners do not have network access during benchmark execution, so the image downloads Go modules and installs runtime dependencies at image build time.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 A saída é escrita em `artifacts/benchmarks/invowk.bmf.json` e pode ser enviada com o adapter `json` do Bencher.
 
-O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, envia essa imagem para o registry do Bencher e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go e instala dependências de runtime durante o build da imagem.
+O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_USER_EMAIL` e `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go e instala dependências de runtime durante o build da imagem.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 A saída é escrita em `artifacts/benchmarks/invowk.bmf.json` e pode ser enviada com o adapter `json` do Bencher.
 
-O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go, aquece o caminho de build dos benchmarks e instala dependências de runtime durante o build da imagem.
+O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem inclui dependências Go vendorizadas e instala dependências de runtime durante o build da imagem.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 O Invowk acompanha a performance de releases no [Bencher](https://bencher.dev/perf/invowk). O histórico público é indexado pela tag de release, então usuários podem comparar versões publicadas como `v0.12.0` e `v0.13.0` diretamente.
 
-Execuções de benchmark em pull requests são guardrails para mantenedores. Elas podem falhar uma mudança quando o Bencher detecta regressão, mas não são o histórico de performance voltado a usuários.
+Execuções de benchmark em pull requests são guardrails para mantenedores. Elas podem falhar uma mudança quando o Bencher detecta regressão, mas não são o histórico de performance voltado a usuários. Pull requests usam a mesma Spec bare-metal do Bencher que as execuções de release.
 
 ## Fluxo de Release
 
@@ -16,6 +16,7 @@ O workflow de release envia JSON no Bencher Metric Format antes de publicar o re
 - `--hash` é o SHA do commit do release.
 - `--start-point` é a tag do release anterior quando ela existe.
 - `--start-point-clone-thresholds` e `--start-point-reset` mantêm thresholds e histórico alinhados de versão para versão.
+- `--image` e `--spec` fazem o Bencher executar o comando de benchmark em runners bare-metal, não no runner do GitHub Actions que empacotou a imagem.
 
 ## Métricas Acompanhadas
 
@@ -35,3 +36,5 @@ make bench-bmf
 ```
 
 A saída é escrita em `artifacts/benchmarks/invowk.bmf.json` e pode ser enviada com o adapter `json` do Bencher.
+
+O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, envia essa imagem para o registry do Bencher e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go e instala dependências de runtime durante o build da imagem.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 A saída é escrita em `artifacts/benchmarks/invowk.bmf.json` e pode ser enviada com o adapter `json` do Bencher.
 
-O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_USER_EMAIL` e `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go e instala dependências de runtime durante o build da imagem.
+O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go e instala dependências de runtime durante o build da imagem.

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/performance/benchmark-history.mdx
@@ -37,4 +37,4 @@ make bench-bmf
 
 A saída é escrita em `artifacts/benchmarks/invowk.bmf.json` e pode ser enviada com o adapter `json` do Bencher.
 
-O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go e instala dependências de runtime durante o build da imagem.
+O CI empacota o código dos benchmarks em uma imagem OCI com `build/bencher/Dockerfile`, faz login no registry do Bencher com `BENCHER_API_TOKEN`, envia a imagem e então chama `bencher run --image ... --spec ...`. Runners bare-metal compartilhados do Bencher não têm acesso à rede durante a execução dos benchmarks, então a imagem baixa módulos Go, aquece o caminho de build dos benchmarks e instala dependências de runtime durante o build da imagem.

--- a/website/src/pages/performance.tsx
+++ b/website/src/pages/performance.tsx
@@ -49,10 +49,10 @@ export default function Performance(): ReactNode {
           <div className={styles.section}>
             <Heading as="h2">Maintainer Workflow</Heading>
             <p>
-              Pull requests use Bencher as a regression gate. Releases use the Git tag as the durable public performance identity.
+              Pull requests use Bencher as a regression gate on the same bare-metal Spec used by releases. Releases use the Git tag as the durable public performance identity.
             </p>
             <p>
-              Local benchmark data can be generated with <code>make bench-bmf</code>; CI uploads that Bencher Metric Format JSON with Bencher's <code>json</code> adapter.
+              Local benchmark data can be generated with <code>make bench-bmf</code>; CI packages the benchmark image and Bencher runs it remotely with the <code>json</code> adapter.
             </p>
           </div>
         </section>


### PR DESCRIPTION
## Summary

- Package benchmark runs into a compact OCI image with vendored Go dependencies for Bencher bare-metal execution.
- Switch PR, fork PR, and release benchmark uploads to `bencher run --image ... --spec intel-v1` with offline Go vendor mode.
- Add shared Bencher threshold arguments and a registry login helper that derives the Docker username from `BENCHER_API_TOKEN`.
- Document the bare-metal benchmark workflow in current docs, pt-BR docs, and the performance page.

## Validation

- `actionlint .github/workflows/benchmarks.yml .github/workflows/benchmarks-upload.yml .github/workflows/release.yml .github/workflows/ci.yml`
- `git diff --check`
- `bash -n scripts/bencher-registry-login.sh scripts/bencher-threshold-args.sh scripts/test_bencher_registry_login.sh`
- `node scripts/test_bench_bmf.mjs`
- `bash scripts/test_bencher_registry_login.sh`
- `GOPROXY=off GOSUMDB=off GOFLAGS=-mod=vendor go test ./internal/benchmark ./internal/app/modulesync ./internal/app/moduleops ./cmd/invowk -run=^$ -bench=^$`
- `npm run docs:parity`
- `npm run build`
- CI on `b9ea78a`: full PR check rollup green, including `Track Benchmarks` on Bencher bare metal.