### PR TITLE
feat(acp): add dormant ACP client foundation

### DIFF
--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -90,6 +90,9 @@ var ErrNotFound = errors.New(notFoundErrMsg)
   context-aware engine/server calls.
 - For long-running subprocesses, set `cmd.WaitDelay` when cancellation or
   pipe-draining can otherwise hang.
+- When capturing subprocess stdout/stderr that may be inspected before
+  `Run`/`Wait` has completed, do not expose a raw `bytes.Buffer`; use a
+  synchronized writer/snapshot type or wait for the process first.
 - `context.Background()` is only for true roots, nil fallback documented on an
   options struct, bounded availability probes, `TestMain`, or independent
   shutdown after caller cancellation.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/charmbracelet/ssh v0.0.0-20250826160808-ebfa259c7309
 	github.com/charmbracelet/wish v1.4.7
 	github.com/charmbracelet/x/xpty v0.1.3
+	github.com/coder/acp-go-sdk v0.13.0
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-git/v5 v5.19.1

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cockroachdb/apd/v3 v3.2.3 h1:4Zx+I3R35bFXMnltzmjP79i2cravE4jTRL6ps9Aux80=
 github.com/cockroachdb/apd/v3 v3.2.3/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
+github.com/coder/acp-go-sdk v0.13.0 h1:IAKBDIbe/iBfKAGikeIndzb8fowt4ioD+gCtSU4HwMA=
+github.com/coder/acp-go-sdk v0.13.0/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/acpclient/client.go
+++ b/internal/acpclient/client.go
@@ -1,0 +1,626 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package acpclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/invowk/invowk/pkg/types"
+)
+
+var _ acp.Client = (*callbackClient)(nil)
+
+type (
+	callbackClient struct {
+		policies Policies
+
+		mu     sync.Mutex
+		events []Event
+	}
+
+	agentProcess struct {
+		cancel          context.CancelFunc
+		stdin           io.WriteCloser
+		wait            <-chan error
+		shutdownTimeout time.Duration
+	}
+)
+
+// RunPrompt launches the configured ACP process, drives one bounded prompt turn,
+// collects streamed updates, and closes the process.
+func RunPrompt(ctx context.Context, opts Options, prompt Prompt) (result Result, err error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return Result{}, newOperationError(operationCancel, ErrACPProtocol, ctxErr, "")
+	}
+	if validateErr := opts.Validate(); validateErr != nil {
+		return Result{}, validateErr
+	}
+	if validateErr := prompt.Validate(); validateErr != nil {
+		return Result{}, validateErr
+	}
+
+	process, stdout, stderr, err := startAgent(ctx, opts)
+	if err != nil {
+		return Result{}, err
+	}
+	defer func() {
+		if closeErr := process.close(); err == nil && closeErr != nil {
+			err = newOperationError(operationProcessExit, ErrAgentProcess, closeErr, stderr.String())
+		}
+	}()
+
+	client := &callbackClient{policies: opts.Policies.Normalize()}
+	conn := acp.NewClientSideConnection(client, process.stdin, stdout)
+
+	initResp, err := conn.Initialize(ctx, acp.InitializeRequest{
+		ProtocolVersion: acp.ProtocolVersionNumber,
+		ClientCapabilities: acp.ClientCapabilities{
+			Fs: acp.FileSystemCapabilities{
+				ReadTextFile:  true,
+				WriteTextFile: true,
+			},
+			Terminal: opts.Policies.Terminal != nil,
+		},
+		ClientInfo: &acp.Implementation{
+			Name:    defaultClientName.String(),
+			Version: defaultClientVersion.String(),
+		},
+	})
+	if err != nil {
+		return Result{}, newOperationError(operationInitialize, ErrACPProtocol, err, stderr.String())
+	}
+
+	session, err := conn.NewSession(ctx, acp.NewSessionRequest{
+		Cwd:        opts.WorkDir.String(),
+		McpServers: []acp.McpServer{},
+	})
+	if err != nil {
+		return Result{}, newOperationError(operationNewSession, ErrACPProtocol, err, stderr.String())
+	}
+
+	promptResp, err := conn.Prompt(ctx, acp.PromptRequest{
+		SessionId: session.SessionId,
+		Prompt:    []acp.ContentBlock{acp.TextBlock(prompt.Text.String())},
+	})
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			cancelErr := sendCancel(conn, session.SessionId)
+			return Result{}, newOperationError(operationCancel, ErrACPProtocol, errors.Join(ctxErr, cancelErr), stderr.String())
+		}
+		return Result{}, newOperationError(operationPrompt, ErrACPProtocol, err, stderr.String())
+	}
+
+	if initResp.AgentCapabilities.SessionCapabilities.Close != nil {
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), opts.ShutdownDuration())
+		defer cancel()
+		if _, err := conn.CloseSession(closeCtx, acp.CloseSessionRequest{SessionId: session.SessionId}); err != nil {
+			return Result{}, newOperationError(operationClose, ErrACPProtocol, err, stderr.String())
+		}
+	}
+
+	return Result{
+		SessionID:  SessionID(session.SessionId),
+		StopReason: StopReason(promptResp.StopReason),
+		Events:     client.Events(),
+	}, nil
+}
+
+func (n clientName) String() string { return string(n) }
+
+func (v clientVersion) String() string { return string(v) }
+
+func startAgent(ctx context.Context, opts Options) (*agentProcess, io.Reader, *bytes.Buffer, error) {
+	processCtx, cancelProcess := context.WithCancel(context.WithoutCancel(ctx))
+	cmd := exec.CommandContext(processCtx, opts.Command.Name.String(), opts.Command.ArgsAsStrings()...)
+	cmd.Dir = opts.WorkDir.String()
+	cmd.WaitDelay = opts.ShutdownDuration()
+	stderr := &bytes.Buffer{}
+	if opts.Stderr != nil {
+		cmd.Stderr = io.MultiWriter(stderr, opts.Stderr)
+	} else {
+		cmd.Stderr = stderr
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancelProcess()
+		return nil, nil, stderr, newOperationError(operationStart, ErrAgentProcess, err, stderr.String())
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancelProcess()
+		return nil, nil, stderr, newOperationError(operationStart, ErrAgentProcess, err, stderr.String())
+	}
+	if err := cmd.Start(); err != nil {
+		cancelProcess()
+		return nil, nil, stderr, newOperationError(operationStart, ErrAgentProcess, err, stderr.String())
+	}
+
+	wait := make(chan error, 1)
+	go func() {
+		wait <- cmd.Wait()
+	}()
+
+	return &agentProcess{
+		cancel:          cancelProcess,
+		stdin:           stdin,
+		wait:            wait,
+		shutdownTimeout: opts.ShutdownDuration(),
+	}, stdout, stderr, nil
+}
+
+func sendCancel(conn *acp.ClientSideConnection, sessionID acp.SessionId) error {
+	cancelCtx, cancel := context.WithTimeout(context.Background(), cancelNotifyTimeout)
+	defer cancel()
+	err := conn.Cancel(cancelCtx, acp.CancelNotification{SessionId: sessionID})
+	timer := time.NewTimer(cancelDrainTimeout)
+	defer timer.Stop()
+	select {
+	case <-conn.Done():
+	case <-timer.C:
+	}
+	if err != nil {
+		return fmt.Errorf("send ACP cancel notification: %w", err)
+	}
+	return nil
+}
+
+func (p *agentProcess) close() error {
+	if p == nil {
+		return nil
+	}
+	if p.stdin != nil {
+		_ = p.stdin.Close()
+	}
+	select {
+	case err := <-p.wait:
+		p.cancel()
+		return err
+	case <-time.After(p.shutdownTimeout):
+		p.cancel()
+		err := <-p.wait
+		if err != nil {
+			return fmt.Errorf("ACP agent did not exit before shutdown timeout: %w", err)
+		}
+		return errors.New("ACP agent did not exit before shutdown timeout")
+	}
+}
+
+// Events returns a snapshot of streamed ACP events.
+func (c *callbackClient) Events() []Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	events := make([]Event, len(c.events))
+	copy(events, c.events)
+	return events
+}
+
+func (c *callbackClient) SessionUpdate(_ context.Context, params acp.SessionNotification) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.events = append(c.events, eventFromSessionUpdate(params.Update))
+	return nil
+}
+
+func (c *callbackClient) RequestPermission(
+	ctx context.Context,
+	params acp.RequestPermissionRequest,
+) (acp.RequestPermissionResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.RequestPermissionResponse{}, newOperationError(operationRequestPermission, ErrACPProtocol, err, "")
+	}
+	toolCall, err := toolCallFromACP(params.ToolCall)
+	if err != nil {
+		return acp.RequestPermissionResponse{}, err
+	}
+	req := PermissionRequest{
+		SessionID: SessionID(params.SessionId),
+		ToolCall:  toolCall,
+		Options:   permissionOptionsFromACP(params.Options),
+	}
+	resp, err := c.policies.Permission.RequestPermission(ctx, req)
+	if err != nil {
+		return acp.RequestPermissionResponse{}, err
+	}
+	if err := resp.Outcome.Validate(); err != nil {
+		return acp.RequestPermissionResponse{}, err
+	}
+	return permissionResponseToACP(resp), nil
+}
+
+func (c *callbackClient) ReadTextFile(
+	ctx context.Context,
+	params acp.ReadTextFileRequest,
+) (acp.ReadTextFileResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.ReadTextFileResponse{}, newOperationError(operationReadTextFile, ErrACPProtocol, err, "")
+	}
+	path, err := filesystemPathFromACP(params.Path)
+	if err != nil {
+		return acp.ReadTextFileResponse{}, err
+	}
+	line, err := lineNumberFromPtr(params.Line)
+	if err != nil {
+		return acp.ReadTextFileResponse{}, err
+	}
+	limit, err := lineLimitFromPtr(params.Limit)
+	if err != nil {
+		return acp.ReadTextFileResponse{}, err
+	}
+	req := ReadTextFileRequest{
+		SessionID: SessionID(params.SessionId),
+		Path:      path,
+		Line:      line,
+		Limit:     limit,
+	}
+	resp, err := c.policies.Filesystem.ReadTextFile(ctx, req)
+	if err != nil {
+		return acp.ReadTextFileResponse{}, err
+	}
+	return acp.ReadTextFileResponse{Content: resp.Content.String()}, nil
+}
+
+func (c *callbackClient) WriteTextFile(
+	ctx context.Context,
+	params acp.WriteTextFileRequest,
+) (acp.WriteTextFileResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.WriteTextFileResponse{}, newOperationError(operationWriteTextFile, ErrACPProtocol, err, "")
+	}
+	path, err := filesystemPathFromACP(params.Path)
+	if err != nil {
+		return acp.WriteTextFileResponse{}, err
+	}
+	req := WriteTextFileRequest{
+		SessionID: SessionID(params.SessionId),
+		Path:      path,
+		Content:   FileContent(params.Content),
+	}
+	if _, err := c.policies.Filesystem.WriteTextFile(ctx, req); err != nil {
+		return acp.WriteTextFileResponse{}, err
+	}
+	return acp.WriteTextFileResponse{}, nil
+}
+
+func (c *callbackClient) CreateTerminal(
+	ctx context.Context,
+	params acp.CreateTerminalRequest,
+) (acp.CreateTerminalResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.CreateTerminalResponse{}, newOperationError(operationCreateTerminal, ErrACPProtocol, err, "")
+	}
+	policy := c.terminalPolicy()
+	req, err := createTerminalRequestFromACP(params)
+	if err != nil {
+		return acp.CreateTerminalResponse{}, err
+	}
+	resp, err := policy.CreateTerminal(ctx, req)
+	if err != nil {
+		return acp.CreateTerminalResponse{}, err
+	}
+	return acp.CreateTerminalResponse{TerminalId: resp.TerminalID.String()}, nil
+}
+
+func (c *callbackClient) TerminalOutput(
+	ctx context.Context,
+	params acp.TerminalOutputRequest,
+) (acp.TerminalOutputResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.TerminalOutputResponse{}, newOperationError(operationTerminalOutput, ErrACPProtocol, err, "")
+	}
+	policy := c.terminalPolicy()
+	resp, err := policy.TerminalOutput(ctx, TerminalOutputRequest{
+		SessionID:  SessionID(params.SessionId),
+		TerminalID: TerminalID(params.TerminalId),
+	})
+	if err != nil {
+		return acp.TerminalOutputResponse{}, err
+	}
+	return acp.TerminalOutputResponse{
+		Output:    resp.Output.String(),
+		Truncated: bool(resp.Truncated),
+	}, nil
+}
+
+func (c *callbackClient) ReleaseTerminal(
+	ctx context.Context,
+	params acp.ReleaseTerminalRequest,
+) (acp.ReleaseTerminalResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.ReleaseTerminalResponse{}, newOperationError(operationReleaseTerminal, ErrACPProtocol, err, "")
+	}
+	policy := c.terminalPolicy()
+	_, err := policy.ReleaseTerminal(ctx, ReleaseTerminalRequest{
+		SessionID:  SessionID(params.SessionId),
+		TerminalID: TerminalID(params.TerminalId),
+	})
+	if err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	return acp.ReleaseTerminalResponse{}, nil
+}
+
+func (c *callbackClient) WaitForTerminalExit(
+	ctx context.Context,
+	params acp.WaitForTerminalExitRequest,
+) (acp.WaitForTerminalExitResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.WaitForTerminalExitResponse{}, newOperationError(operationWaitForTerminalExit, ErrACPProtocol, err, "")
+	}
+	policy := c.terminalPolicy()
+	resp, err := policy.WaitForTerminalExit(ctx, WaitForTerminalExitRequest{
+		SessionID:  SessionID(params.SessionId),
+		TerminalID: TerminalID(params.TerminalId),
+	})
+	if err != nil {
+		return acp.WaitForTerminalExitResponse{}, err
+	}
+	return acp.WaitForTerminalExitResponse{
+		ExitCode: exitCodeToPtr(resp.ExitCode),
+		Signal:   signalToPtr(resp.Signal),
+	}, nil
+}
+
+func (c *callbackClient) KillTerminal(
+	ctx context.Context,
+	params acp.KillTerminalRequest,
+) (acp.KillTerminalResponse, error) {
+	if err := params.Validate(); err != nil {
+		return acp.KillTerminalResponse{}, newOperationError(operationKillTerminal, ErrACPProtocol, err, "")
+	}
+	policy := c.terminalPolicy()
+	_, err := policy.KillTerminal(ctx, KillTerminalRequest{
+		SessionID:  SessionID(params.SessionId),
+		TerminalID: TerminalID(params.TerminalId),
+	})
+	if err != nil {
+		return acp.KillTerminalResponse{}, err
+	}
+	return acp.KillTerminalResponse{}, nil
+}
+
+func (c *callbackClient) terminalPolicy() TerminalPolicy {
+	if c.policies.Terminal != nil {
+		return c.policies.Terminal
+	}
+	return RestrictivePolicy{}
+}
+
+func eventFromSessionUpdate(update acp.SessionUpdate) Event {
+	switch {
+	case update.AgentMessageChunk != nil:
+		return Event{
+			Kind: EventKindAgentMessage,
+			Text: textFromContentBlock(update.AgentMessageChunk.Content),
+		}
+	case update.AgentThoughtChunk != nil:
+		return Event{
+			Kind: EventKindAgentThought,
+			Text: textFromContentBlock(update.AgentThoughtChunk.Content),
+		}
+	case update.ToolCall != nil:
+		return Event{
+			Kind:       EventKindToolCall,
+			ToolCallID: ToolCallID(update.ToolCall.ToolCallId),
+			ToolTitle:  ToolTitle(update.ToolCall.Title),
+			ToolKind:   ToolKind(update.ToolCall.Kind),
+			ToolStatus: ToolStatus(update.ToolCall.Status),
+		}
+	case update.ToolCallUpdate != nil:
+		return Event{
+			Kind:       EventKindToolCallUpdate,
+			Text:       textFromToolContent(update.ToolCallUpdate.Content),
+			ToolCallID: ToolCallID(update.ToolCallUpdate.ToolCallId),
+			ToolTitle:  toolTitleFromPtr(update.ToolCallUpdate.Title),
+			ToolKind:   toolKindFromPtr(update.ToolCallUpdate.Kind),
+			ToolStatus: toolStatusFromPtr(update.ToolCallUpdate.Status),
+		}
+	case update.Plan != nil:
+		return Event{Kind: EventKindPlan}
+	default:
+		return Event{Kind: EventKindUnknown}
+	}
+}
+
+func textFromContentBlock(block acp.ContentBlock) EventText {
+	if block.Text == nil {
+		return ""
+	}
+	return EventText(block.Text.Text)
+}
+
+func textFromToolContent(content []acp.ToolCallContent) EventText {
+	parts := make([]string, 0, len(content))
+	for _, item := range content {
+		if item.Content != nil && item.Content.Content.Text != nil {
+			parts = append(parts, item.Content.Content.Text.Text)
+		}
+	}
+	return EventText(strings.Join(parts, "\n"))
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive string pointers for optional labels.
+func toolTitleFromPtr(title *string) ToolTitle {
+	if title == nil {
+		return ""
+	}
+	return ToolTitle(*title)
+}
+
+func toolKindFromPtr(kind *acp.ToolKind) ToolKind {
+	if kind == nil {
+		return ""
+	}
+	return ToolKind(*kind)
+}
+
+func toolStatusFromPtr(status *acp.ToolCallStatus) ToolStatus {
+	if status == nil {
+		return ""
+	}
+	return ToolStatus(*status)
+}
+
+func toolCallFromACP(tool acp.ToolCallUpdate) (ToolCall, error) {
+	locations := make([]types.FilesystemPath, 0, len(tool.Locations))
+	for _, location := range tool.Locations {
+		path, err := filesystemPathFromACP(location.Path)
+		if err != nil {
+			return ToolCall{}, err
+		}
+		locations = append(locations, path)
+	}
+	return ToolCall{
+		ID:        ToolCallID(tool.ToolCallId),
+		Title:     toolTitleFromPtr(tool.Title),
+		Kind:      toolKindFromPtr(tool.Kind),
+		Status:    toolStatusFromPtr(tool.Status),
+		Locations: locations,
+	}, nil
+}
+
+func permissionOptionsFromACP(options []acp.PermissionOption) []PermissionOption {
+	result := make([]PermissionOption, 0, len(options))
+	for _, option := range options {
+		result = append(result, PermissionOption{
+			ID:   PermissionOptionID(option.OptionId),
+			Kind: PermissionOptionKind(option.Kind),
+			Name: PermissionOptionName(option.Name),
+		})
+	}
+	return result
+}
+
+func permissionResponseToACP(resp PermissionResponse) acp.RequestPermissionResponse {
+	outcome := acp.RequestPermissionOutcome{}
+	switch resp.Outcome.Kind {
+	case PermissionOutcomeKindSelected:
+		outcome.Selected = &acp.RequestPermissionOutcomeSelected{
+			OptionId: acp.PermissionOptionId(resp.Outcome.SelectedOptionID),
+		}
+	case PermissionOutcomeKindCancelled:
+		outcome.Cancelled = &acp.RequestPermissionOutcomeCancelled{}
+	}
+	return acp.RequestPermissionResponse{Outcome: outcome}
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive int pointers for optional line numbers.
+//nolint:nilnil // A nil line with nil error is the ACP "field absent" value.
+func lineNumberFromPtr(line *int) (*LineNumber, error) {
+	if line == nil {
+		return nil, nil
+	}
+	value := LineNumber(*line)
+	if err := value.Validate(); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive int pointers for optional line limits.
+//nolint:nilnil // A nil limit with nil error is the ACP "field absent" value.
+func lineLimitFromPtr(limit *int) (*LineLimit, error) {
+	if limit == nil {
+		return nil, nil
+	}
+	value := LineLimit(*limit)
+	if err := value.Validate(); err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func createTerminalRequestFromACP(params acp.CreateTerminalRequest) (CreateTerminalRequest, error) {
+	args := make([]TerminalArgument, 0, len(params.Args))
+	for _, arg := range params.Args {
+		args = append(args, TerminalArgument(arg))
+	}
+	env := make([]TerminalEnv, 0, len(params.Env))
+	for _, item := range params.Env {
+		env = append(env, TerminalEnv{
+			Name:  TerminalEnvName(item.Name),
+			Value: TerminalEnvValue(item.Value),
+		})
+	}
+	workDir, err := workDirFromPtr(params.Cwd)
+	if err != nil {
+		return CreateTerminalRequest{}, err
+	}
+	return CreateTerminalRequest{
+		SessionID:       SessionID(params.SessionId),
+		Command:         TerminalCommand(params.Command),
+		Args:            args,
+		WorkDir:         workDir,
+		Env:             env,
+		OutputByteLimit: terminalOutputLimitFromPtr(params.OutputByteLimit),
+	}, nil
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive string pointers for optional cwd.
+//nolint:nilnil // A nil cwd with nil error is the ACP "field absent" value.
+func workDirFromPtr(path *string) (*types.FilesystemPath, error) {
+	if path == nil {
+		return nil, nil
+	}
+	value, err := filesystemPathFromACP(*path)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive int pointers for optional output limits.
+func terminalOutputLimitFromPtr(limit *int) *TerminalOutputLimit {
+	if limit == nil {
+		return nil
+	}
+	value := TerminalOutputLimit(*limit)
+	return &value
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive int pointers for optional exit codes.
+func exitCodeToPtr(exitCode *types.ExitCode) *int {
+	if exitCode == nil {
+		return nil
+	}
+	value := int(*exitCode)
+	return &value
+}
+
+//goplint:ignore -- ACP generated protocol uses primitive string pointers for optional signals.
+func signalToPtr(signal TerminalSignal) *string {
+	if signal == "" {
+		return nil
+	}
+	value := signal.String()
+	return &value
+}
+
+func filesystemPathFromACP(path string) (types.FilesystemPath, error) {
+	value := types.FilesystemPath(path) //goplint:ignore -- ACP protocol path is validated immediately below.
+	if err := value.Validate(); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+//goplint:ignore -- stderr is captured from os/exec as raw process text at the adapter boundary.
+func newOperationError(operation Operation, kind, err error, stderr string) error {
+	return &OperationError{
+		Operation: operation,
+		Kind:      kind,
+		Err:       err,
+		Stderr:    AgentStderr(strings.TrimSpace(stderr)),
+	}
+}

--- a/internal/acpclient/client.go
+++ b/internal/acpclient/client.go
@@ -33,6 +33,11 @@ type (
 		wait            <-chan error
 		shutdownTimeout time.Duration
 	}
+
+	stderrCapture struct {
+		mu     sync.Mutex
+		buffer bytes.Buffer
+	}
 )
 
 // RunPrompt launches the configured ACP process, drives one bounded prompt turn,
@@ -118,12 +123,12 @@ func (n clientName) String() string { return string(n) }
 
 func (v clientVersion) String() string { return string(v) }
 
-func startAgent(ctx context.Context, opts Options) (*agentProcess, io.Reader, *bytes.Buffer, error) {
+func startAgent(ctx context.Context, opts Options) (*agentProcess, io.Reader, *stderrCapture, error) {
 	processCtx, cancelProcess := context.WithCancel(context.WithoutCancel(ctx))
 	cmd := exec.CommandContext(processCtx, opts.Command.Name.String(), opts.Command.ArgsAsStrings()...)
 	cmd.Dir = opts.WorkDir.String()
 	cmd.WaitDelay = opts.ShutdownDuration()
-	stderr := &bytes.Buffer{}
+	stderr := &stderrCapture{}
 	if opts.Stderr != nil {
 		cmd.Stderr = io.MultiWriter(stderr, opts.Stderr)
 	} else {
@@ -156,6 +161,20 @@ func startAgent(ctx context.Context, opts Options) (*agentProcess, io.Reader, *b
 		wait:            wait,
 		shutdownTimeout: opts.ShutdownDuration(),
 	}, stdout, stderr, nil
+}
+
+func (s *stderrCapture) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buffer.Write(p)
+}
+
+func (s *stderrCapture) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buffer.String()
 }
 
 func sendCancel(conn *acp.ClientSideConnection, sessionID acp.SessionId) error {

--- a/internal/acpclient/client_test.go
+++ b/internal/acpclient/client_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package acpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/invowk/invowk/pkg/types"
+)
+
+const (
+	fakeAgentEnv           = "INVOWK_ACPCLIENT_FAKE_AGENT"
+	fakeAgentScenarioEnv   = "INVOWK_ACPCLIENT_FAKE_SCENARIO"
+	fakeAgentStartFileEnv  = "INVOWK_ACPCLIENT_FAKE_START_FILE"
+	fakeAgentCancelFileEnv = "INVOWK_ACPCLIENT_FAKE_CANCEL_FILE"
+
+	fakeAgentScenarioSuccess = "success"
+	fakeAgentScenarioCancel  = "cancel"
+)
+
+var _ acp.Agent = (*fakeAgent)(nil)
+
+type fakeAgent struct {
+	conn         *acp.AgentSideConnection
+	scenario     string
+	startMarker  types.FilesystemPath
+	cancelMarker types.FilesystemPath
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv(fakeAgentEnv) == "1" {
+		os.Exit(runFakeAgentProcess())
+	}
+	os.Exit(m.Run())
+}
+
+func TestRunPromptWithFakeAgent(t *testing.T) {
+	t.Setenv(fakeAgentEnv, "1")
+	t.Setenv(fakeAgentScenarioEnv, fakeAgentScenarioSuccess)
+
+	result, err := RunPrompt(t.Context(), fakeOptions(t), Prompt{Text: PromptText("hello")})
+	if err != nil {
+		t.Fatalf("RunPrompt() error = %v", err)
+	}
+	if result.SessionID != "fake-session" {
+		t.Fatalf("SessionID = %q, want fake-session", result.SessionID)
+	}
+	if result.StopReason != StopReason(acp.StopReasonEndTurn) {
+		t.Fatalf("StopReason = %q, want %q", result.StopReason, acp.StopReasonEndTurn)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(result.Events))
+	}
+	event := result.Events[0]
+	if event.Kind != EventKindAgentMessage {
+		t.Fatalf("event.Kind = %q, want %q", event.Kind, EventKindAgentMessage)
+	}
+	if event.Text != "hello from fake agent" {
+		t.Fatalf("event.Text = %q, want fake agent text", event.Text)
+	}
+}
+
+func TestRunPromptCancellationForwardsCancel(t *testing.T) {
+	startFile := types.FilesystemPath(t.TempDir() + "/started")
+	cancelFile := types.FilesystemPath(t.TempDir() + "/cancelled")
+	t.Setenv(fakeAgentEnv, "1")
+	t.Setenv(fakeAgentScenarioEnv, fakeAgentScenarioCancel)
+	t.Setenv(fakeAgentStartFileEnv, startFile.String())
+	t.Setenv(fakeAgentCancelFileEnv, cancelFile.String())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := RunPrompt(ctx, fakeOptions(t), Prompt{Text: PromptText("cancel me")})
+		errCh <- err
+	}()
+
+	waitForFile(t, startFile)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunPrompt() error = %v, want context.Canceled", err)
+		}
+		if !errors.Is(err, ErrACPProtocol) {
+			t.Fatalf("RunPrompt() error = %v, want ErrACPProtocol", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunPrompt() did not return after cancellation")
+	}
+	waitForFile(t, cancelFile)
+}
+
+func fakeOptions(t *testing.T) Options {
+	t.Helper()
+	return Options{
+		Command: Command{
+			Name: CommandName(os.Args[0]),
+			Args: []CommandArgument{"-test.run=TestFakeACPAgentProcess"},
+		},
+		WorkDir: types.FilesystemPath(t.TempDir()),
+	}
+}
+
+func runFakeAgentProcess() int {
+	agent := &fakeAgent{
+		scenario:     os.Getenv(fakeAgentScenarioEnv),
+		startMarker:  types.FilesystemPath(os.Getenv(fakeAgentStartFileEnv)),
+		cancelMarker: types.FilesystemPath(os.Getenv(fakeAgentCancelFileEnv)),
+	}
+	conn := acp.NewAgentSideConnection(agent, os.Stdout, os.Stdin)
+	agent.conn = conn
+	<-conn.Done()
+	return 0
+}
+
+func (a *fakeAgent) Authenticate(context.Context, acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	return acp.AuthenticateResponse{}, nil
+}
+
+func (a *fakeAgent) Initialize(context.Context, acp.InitializeRequest) (acp.InitializeResponse, error) {
+	return acp.InitializeResponse{
+		ProtocolVersion: acp.ProtocolVersionNumber,
+		AgentInfo: &acp.Implementation{
+			Name:    "fake-agent",
+			Version: "test",
+		},
+		AgentCapabilities: acp.AgentCapabilities{
+			SessionCapabilities: acp.SessionCapabilities{
+				Close: &acp.SessionCloseCapabilities{},
+			},
+		},
+	}, nil
+}
+
+func (a *fakeAgent) Cancel(context.Context, acp.CancelNotification) error {
+	if a.cancelMarker != "" {
+		return os.WriteFile(a.cancelMarker.String(), []byte("cancelled"), 0o600)
+	}
+	return nil
+}
+
+func (a *fakeAgent) CloseSession(context.Context, acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	return acp.CloseSessionResponse{}, nil
+}
+
+func (a *fakeAgent) ListSessions(context.Context, acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	return acp.ListSessionsResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionList)
+}
+
+func (a *fakeAgent) NewSession(context.Context, acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	return acp.NewSessionResponse{SessionId: "fake-session"}, nil
+}
+
+func (a *fakeAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
+	switch a.scenario {
+	case fakeAgentScenarioCancel:
+		if a.startMarker != "" {
+			if err := os.WriteFile(a.startMarker.String(), []byte("started"), 0o600); err != nil {
+				return acp.PromptResponse{}, err
+			}
+		}
+		<-ctx.Done()
+		return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, fmt.Errorf("fake prompt canceled: %w", ctx.Err())
+	default:
+		if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{
+			SessionId: params.SessionId,
+			Update:    acp.UpdateAgentMessageText("hello from fake agent"),
+		}); err != nil {
+			return acp.PromptResponse{}, fmt.Errorf("send fake session update: %w", err)
+		}
+		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+	}
+}
+
+func (a *fakeAgent) ResumeSession(context.Context, acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	return acp.ResumeSessionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionResume)
+}
+
+func (a *fakeAgent) SetSessionConfigOption(
+	context.Context,
+	acp.SetSessionConfigOptionRequest,
+) (acp.SetSessionConfigOptionResponse, error) {
+	return acp.SetSessionConfigOptionResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetConfigOption)
+}
+
+func (a *fakeAgent) SetSessionMode(context.Context, acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	return acp.SetSessionModeResponse{}, acp.NewMethodNotFound(acp.AgentMethodSessionSetMode)
+}
+
+func waitForFile(t *testing.T, path types.FilesystemPath) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path.String()); err == nil {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", path)
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/acpclient/doc.go
+++ b/internal/acpclient/doc.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+
+// Package acpclient provides a dormant internal Agent Client Protocol client
+// foundation for future stateful agent-session features.
+//
+// This package is intentionally not wired into any current CLI command,
+// configuration schema, CUE schema, or documentation surface. Existing LLM
+// workflows continue to use their current direct provider and completion paths.
+package acpclient

--- a/internal/acpclient/import_boundary_test.go
+++ b/internal/acpclient/import_boundary_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package acpclient
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const acpSDKImportPath = "github.com/coder/acp-go-sdk"
+
+type listedPackage struct {
+	ImportPath   string
+	Imports      []string
+	TestImports  []string
+	XTestImports []string
+}
+
+func TestACPSDKImportsStayInsideFoundation(t *testing.T) {
+	root := repoRoot(t)
+	cmd := exec.CommandContext(
+		t.Context(),
+		"go",
+		"list",
+		"-json",
+		"./cmd/...",
+		"./internal/...",
+		"./pkg/...",
+	)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			t.Fatalf("go list failed: %v\n%s", err, exitErr.Stderr)
+		}
+		t.Fatalf("go list failed: %v", err)
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(string(out)))
+	for {
+		var pkg listedPackage
+		if err := decoder.Decode(&pkg); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			t.Fatalf("decode go list output: %v", err)
+		}
+		if packageImportsACP(pkg) && !strings.HasPrefix(pkg.ImportPath, "github.com/invowk/invowk/internal/acpclient") {
+			t.Fatalf("%s imports %s outside internal/acpclient", pkg.ImportPath, acpSDKImportPath)
+		}
+	}
+}
+
+func packageImportsACP(pkg listedPackage) bool {
+	return slices.Contains(pkg.Imports, acpSDKImportPath) ||
+		slices.Contains(pkg.TestImports, acpSDKImportPath) ||
+		slices.Contains(pkg.XTestImports, acpSDKImportPath)
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get wd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repository root")
+		}
+		dir = parent
+	}
+}

--- a/internal/acpclient/policy.go
+++ b/internal/acpclient/policy.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package acpclient
+
+import (
+	"context"
+	"fmt"
+)
+
+//goplint:ignore -- ACP callback policies are adapter ports; zero-value policy grouping is valid.
+type (
+	// PermissionPolicy mediates ACP permission prompts.
+	PermissionPolicy interface {
+		RequestPermission(context.Context, PermissionRequest) (PermissionResponse, error)
+	}
+
+	// FilesystemPolicy mediates ACP text-file callbacks.
+	FilesystemPolicy interface {
+		ReadTextFile(context.Context, ReadTextFileRequest) (ReadTextFileResponse, error)
+		WriteTextFile(context.Context, WriteTextFileRequest) (WriteTextFileResponse, error)
+	}
+
+	// TerminalPolicy mediates ACP terminal callbacks.
+	TerminalPolicy interface {
+		CreateTerminal(context.Context, CreateTerminalRequest) (CreateTerminalResponse, error)
+		TerminalOutput(context.Context, TerminalOutputRequest) (TerminalOutputResponse, error)
+		ReleaseTerminal(context.Context, ReleaseTerminalRequest) (ReleaseTerminalResponse, error)
+		WaitForTerminalExit(context.Context, WaitForTerminalExitRequest) (WaitForTerminalExitResponse, error)
+		KillTerminal(context.Context, KillTerminalRequest) (KillTerminalResponse, error)
+	}
+
+	// Policies groups the ACP callback policies used by one prompt run.
+	Policies struct {
+		Permission PermissionPolicy
+		Filesystem FilesystemPolicy
+		Terminal   TerminalPolicy
+	}
+
+	// RestrictivePolicy denies filesystem callbacks, cancels permission prompts,
+	// and reports terminal callbacks as unsupported.
+	RestrictivePolicy struct{}
+)
+
+// Normalize fills unset policies with restrictive behavior.
+func (p Policies) Normalize() Policies {
+	restrictive := RestrictivePolicy{}
+	if p.Permission == nil {
+		p.Permission = restrictive
+	}
+	if p.Filesystem == nil {
+		p.Filesystem = restrictive
+	}
+	return p
+}
+
+// RequestPermission cancels permission prompts by default.
+func (RestrictivePolicy) RequestPermission(context.Context, PermissionRequest) (PermissionResponse, error) {
+	return PermissionResponse{Outcome: CancelledPermissionOutcome()}, nil
+}
+
+// ReadTextFile denies file reads by default.
+func (RestrictivePolicy) ReadTextFile(context.Context, ReadTextFileRequest) (ReadTextFileResponse, error) {
+	return ReadTextFileResponse{}, fmt.Errorf("%w: read text file", ErrPolicyDenied)
+}
+
+// WriteTextFile denies file writes by default.
+func (RestrictivePolicy) WriteTextFile(context.Context, WriteTextFileRequest) (WriteTextFileResponse, error) {
+	return WriteTextFileResponse{}, fmt.Errorf("%w: write text file", ErrPolicyDenied)
+}
+
+// CreateTerminal reports terminal creation as unsupported by default.
+func (RestrictivePolicy) CreateTerminal(context.Context, CreateTerminalRequest) (CreateTerminalResponse, error) {
+	return CreateTerminalResponse{}, fmt.Errorf("%w: create terminal", ErrUnsupportedOperation)
+}
+
+// TerminalOutput reports terminal output as unsupported by default.
+func (RestrictivePolicy) TerminalOutput(context.Context, TerminalOutputRequest) (TerminalOutputResponse, error) {
+	return TerminalOutputResponse{}, fmt.Errorf("%w: terminal output", ErrUnsupportedOperation)
+}
+
+// ReleaseTerminal reports terminal release as unsupported by default.
+func (RestrictivePolicy) ReleaseTerminal(context.Context, ReleaseTerminalRequest) (ReleaseTerminalResponse, error) {
+	return ReleaseTerminalResponse{}, fmt.Errorf("%w: release terminal", ErrUnsupportedOperation)
+}
+
+// WaitForTerminalExit reports terminal waits as unsupported by default.
+func (RestrictivePolicy) WaitForTerminalExit(context.Context, WaitForTerminalExitRequest) (WaitForTerminalExitResponse, error) {
+	return WaitForTerminalExitResponse{}, fmt.Errorf("%w: wait for terminal exit", ErrUnsupportedOperation)
+}
+
+// KillTerminal reports terminal kill requests as unsupported by default.
+func (RestrictivePolicy) KillTerminal(context.Context, KillTerminalRequest) (KillTerminalResponse, error) {
+	return KillTerminalResponse{}, fmt.Errorf("%w: kill terminal", ErrUnsupportedOperation)
+}

--- a/internal/acpclient/policy_test.go
+++ b/internal/acpclient/policy_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package acpclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	acp "github.com/coder/acp-go-sdk"
+)
+
+var (
+	_ PermissionPolicy = (*recordingPermissionPolicy)(nil)
+	_ FilesystemPolicy = (*recordingFilesystemPolicy)(nil)
+)
+
+type (
+	recordingPermissionPolicy struct {
+		request PermissionRequest
+	}
+
+	recordingFilesystemPolicy struct {
+		readRequest  ReadTextFileRequest
+		writeRequest WriteTextFileRequest
+	}
+)
+
+func TestCallbackClientDelegatesPermissionPolicy(t *testing.T) {
+	policy := &recordingPermissionPolicy{}
+	client := &callbackClient{policies: Policies{Permission: policy}.Normalize()}
+	title := "Edit config"
+	kind := acp.ToolKindEdit
+	status := acp.ToolCallStatusPending
+
+	resp, err := client.RequestPermission(t.Context(), acp.RequestPermissionRequest{
+		SessionId: "session-1",
+		ToolCall: acp.ToolCallUpdate{
+			ToolCallId: "tool-1",
+			Title:      &title,
+			Kind:       &kind,
+			Status:     &status,
+			Locations:  []acp.ToolCallLocation{{Path: "/tmp/config.cue"}},
+		},
+		Options: []acp.PermissionOption{
+			{OptionId: "allow", Kind: acp.PermissionOptionKindAllowOnce, Name: "Allow"},
+			{OptionId: "reject", Kind: acp.PermissionOptionKindRejectOnce, Name: "Reject"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RequestPermission() error = %v", err)
+	}
+	if policy.request.SessionID != "session-1" {
+		t.Fatalf("SessionID = %q, want session-1", policy.request.SessionID)
+	}
+	if policy.request.ToolCall.ID != "tool-1" {
+		t.Fatalf("ToolCall.ID = %q, want tool-1", policy.request.ToolCall.ID)
+	}
+	if got := policy.request.ToolCall.Locations[0]; got != "/tmp/config.cue" {
+		t.Fatalf("ToolCall.Locations[0] = %q, want /tmp/config.cue", got)
+	}
+	if resp.Outcome.Selected == nil {
+		t.Fatal("response outcome selected = nil, want selected")
+	}
+	if resp.Outcome.Selected.OptionId != "allow" {
+		t.Fatalf("selected option = %q, want allow", resp.Outcome.Selected.OptionId)
+	}
+}
+
+func TestCallbackClientDelegatesFilesystemPolicy(t *testing.T) {
+	policy := &recordingFilesystemPolicy{}
+	client := &callbackClient{policies: Policies{Filesystem: policy}.Normalize()}
+	line := 2
+	limit := 3
+
+	readResp, err := client.ReadTextFile(t.Context(), acp.ReadTextFileRequest{
+		SessionId: "session-1",
+		Path:      "/tmp/readme.md",
+		Line:      &line,
+		Limit:     &limit,
+	})
+	if err != nil {
+		t.Fatalf("ReadTextFile() error = %v", err)
+	}
+	if readResp.Content != "file content from policy" {
+		t.Fatalf("read content = %q, want policy content", readResp.Content)
+	}
+	if policy.readRequest.Path != "/tmp/readme.md" {
+		t.Fatalf("read path = %q, want /tmp/readme.md", policy.readRequest.Path)
+	}
+	if policy.readRequest.Line == nil || *policy.readRequest.Line != 2 {
+		t.Fatalf("read line = %v, want 2", policy.readRequest.Line)
+	}
+	if policy.readRequest.Limit == nil || *policy.readRequest.Limit != 3 {
+		t.Fatalf("read limit = %v, want 3", policy.readRequest.Limit)
+	}
+
+	_, err = client.WriteTextFile(t.Context(), acp.WriteTextFileRequest{
+		SessionId: "session-1",
+		Path:      "/tmp/readme.md",
+		Content:   "updated by policy",
+	})
+	if err != nil {
+		t.Fatalf("WriteTextFile() error = %v", err)
+	}
+	if policy.writeRequest.Path != "/tmp/readme.md" {
+		t.Fatalf("write path = %q, want /tmp/readme.md", policy.writeRequest.Path)
+	}
+	if policy.writeRequest.Content != "updated by policy" {
+		t.Fatalf("write content = %q, want updated by policy", policy.writeRequest.Content)
+	}
+}
+
+func TestCallbackClientReportsUnsupportedTerminalWithoutPolicy(t *testing.T) {
+	client := &callbackClient{policies: Policies{}.Normalize()}
+
+	_, err := client.CreateTerminal(t.Context(), acp.CreateTerminalRequest{
+		SessionId: "session-1",
+		Command:   "echo",
+		Args:      []string{"hello"},
+	})
+	if !errors.Is(err, ErrUnsupportedOperation) {
+		t.Fatalf("CreateTerminal() error = %v, want ErrUnsupportedOperation", err)
+	}
+}
+
+func TestRestrictivePolicyDeniesByDefault(t *testing.T) {
+	policy := RestrictivePolicy{}
+
+	permissionResp, err := policy.RequestPermission(t.Context(), PermissionRequest{})
+	if err != nil {
+		t.Fatalf("RequestPermission() error = %v", err)
+	}
+	if permissionResp.Outcome.Kind != PermissionOutcomeKindCancelled {
+		t.Fatalf("permission outcome = %q, want cancelled", permissionResp.Outcome.Kind)
+	}
+	_, err = policy.ReadTextFile(t.Context(), ReadTextFileRequest{Path: "/tmp/nope"})
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("ReadTextFile() error = %v, want ErrPolicyDenied", err)
+	}
+	_, err = policy.CreateTerminal(t.Context(), CreateTerminalRequest{Command: "echo"})
+	if !errors.Is(err, ErrUnsupportedOperation) {
+		t.Fatalf("CreateTerminal() error = %v, want ErrUnsupportedOperation", err)
+	}
+}
+
+func (p *recordingPermissionPolicy) RequestPermission(
+	_ context.Context,
+	request PermissionRequest,
+) (PermissionResponse, error) {
+	p.request = request
+	return PermissionResponse{Outcome: SelectedPermissionOutcome("allow")}, nil
+}
+
+func (p *recordingFilesystemPolicy) ReadTextFile(
+	_ context.Context,
+	request ReadTextFileRequest,
+) (ReadTextFileResponse, error) {
+	p.readRequest = request
+	return ReadTextFileResponse{Content: "file content from policy"}, nil
+}
+
+func (p *recordingFilesystemPolicy) WriteTextFile(
+	_ context.Context,
+	request WriteTextFileRequest,
+) (WriteTextFileResponse, error) {
+	p.writeRequest = request
+	return WriteTextFileResponse{}, nil
+}

--- a/internal/acpclient/types.go
+++ b/internal/acpclient/types.go
@@ -1,0 +1,526 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package acpclient
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/invowk/invowk/pkg/types"
+)
+
+const (
+	defaultClientName      clientName    = "invowk"
+	defaultClientVersion   clientVersion = "internal-acp-foundation"
+	defaultShutdownTimeout               = 5 * time.Second
+	cancelNotifyTimeout                  = time.Second
+	cancelDrainTimeout                   = 100 * time.Millisecond
+
+	operationStart               Operation = "start ACP agent"
+	operationInitialize          Operation = "initialize ACP session"
+	operationNewSession          Operation = "create ACP session"
+	operationPrompt              Operation = "run ACP prompt"
+	operationClose               Operation = "close ACP session"
+	operationCancel              Operation = "cancel ACP prompt"
+	operationProcessExit         Operation = "wait for ACP agent process"
+	operationRequestPermission   Operation = "handle ACP permission request"
+	operationReadTextFile        Operation = "handle ACP file read request"
+	operationWriteTextFile       Operation = "handle ACP file write request"
+	operationCreateTerminal      Operation = "handle ACP terminal create request"
+	operationTerminalOutput      Operation = "handle ACP terminal output request"
+	operationReleaseTerminal     Operation = "handle ACP terminal release request"
+	operationWaitForTerminalExit Operation = "handle ACP terminal wait request"
+	operationKillTerminal        Operation = "handle ACP terminal kill request"
+
+	// EventKindAgentMessage indicates streamed assistant text from the ACP agent.
+	EventKindAgentMessage EventKind = "agent_message"
+	// EventKindAgentThought indicates streamed thought/reasoning text from the ACP agent.
+	EventKindAgentThought EventKind = "agent_thought"
+	// EventKindToolCall indicates a tool call started.
+	EventKindToolCall EventKind = "tool_call"
+	// EventKindToolCallUpdate indicates a tool call status/content update.
+	EventKindToolCallUpdate EventKind = "tool_call_update"
+	// EventKindPlan indicates an ACP plan update.
+	EventKindPlan EventKind = "plan"
+	// EventKindUnknown indicates an ACP update variant this foundation does not yet model.
+	EventKindUnknown EventKind = "unknown"
+
+	// PermissionOutcomeKindSelected means the policy selected one ACP permission option.
+	PermissionOutcomeKindSelected PermissionOutcomeKind = "selected"
+	// PermissionOutcomeKindCancelled means the policy cancelled the permission request.
+	PermissionOutcomeKindCancelled PermissionOutcomeKind = "cancelled"
+)
+
+var (
+	// ErrInvalidOptions is the sentinel wrapped when ACP foundation options are invalid.
+	ErrInvalidOptions = errors.New("invalid ACP client options")
+	// ErrAgentProcess is the sentinel wrapped when the ACP agent process fails.
+	ErrAgentProcess = errors.New("ACP agent process error")
+	// ErrACPProtocol is the sentinel wrapped when ACP negotiation or prompt calls fail.
+	ErrACPProtocol = errors.New("ACP protocol error")
+	// ErrPolicyDenied is the sentinel wrapped when the configured policy denies an ACP callback.
+	ErrPolicyDenied = errors.New("ACP policy denied operation")
+	// ErrUnsupportedOperation is the sentinel wrapped when an ACP callback is not supported.
+	ErrUnsupportedOperation = errors.New("unsupported ACP operation")
+)
+
+//goplint:ignore -- ACP protocol adapter values mirror external protocol labels; DTOs are translated and validated at package boundaries.
+type (
+	clientName    string
+	clientVersion string
+
+	// CommandName is an executable path or name supplied by a future ACP caller.
+	CommandName string
+	// CommandArgument is one raw argv item supplied to an ACP agent process.
+	CommandArgument string
+	// PromptText is the user prompt text sent for a bounded ACP turn.
+	PromptText string
+	// SessionID is an ACP session identifier translated into an Invowk-owned type.
+	SessionID string
+	// StopReason is the ACP stop reason translated into an Invowk-owned type.
+	StopReason string
+	// EventKind categorizes an ACP streamed update.
+	EventKind string
+	// EventText contains display text extracted from ACP update content.
+	EventText string
+	// ToolCallID identifies an ACP tool call.
+	ToolCallID string
+	// ToolTitle is display text for an ACP tool call.
+	ToolTitle string
+	// ToolKind is the ACP tool category translated into an Invowk-owned type.
+	ToolKind string
+	// ToolStatus is the ACP tool status translated into an Invowk-owned type.
+	ToolStatus string
+	// PermissionOptionID identifies a permission option offered by an ACP agent.
+	PermissionOptionID string
+	// PermissionOptionKind categorizes an ACP permission option.
+	PermissionOptionKind string
+	// PermissionOptionName is display text for a permission option.
+	PermissionOptionName string
+	// PermissionOutcomeKind identifies the kind of permission response.
+	PermissionOutcomeKind string
+	// FileContent carries text content mediated by the filesystem policy.
+	FileContent string
+	// LineNumber is a one-based file line number requested by ACP.
+	LineNumber int
+	// LineLimit is the maximum number of file lines requested by ACP.
+	LineLimit int
+	// TerminalCommand is a command requested through an ACP terminal callback.
+	TerminalCommand string
+	// TerminalArgument is one raw argv item requested through an ACP terminal callback.
+	TerminalArgument string
+	// TerminalEnvName is a terminal environment variable name.
+	TerminalEnvName string
+	// TerminalEnvValue is a terminal environment variable value.
+	TerminalEnvValue string
+	// TerminalID identifies a terminal created through ACP.
+	TerminalID string
+	// TerminalOutput contains output returned by a terminal callback.
+	TerminalOutput string
+	// TerminalOutputLimit is an ACP terminal output byte limit.
+	TerminalOutputLimit int
+	// TerminalSignal is a signal name returned by a terminal callback.
+	TerminalSignal string
+	// TerminalOutputTruncated records whether terminal output was truncated.
+	TerminalOutputTruncated bool
+	// Operation names the ACP foundation lifecycle step that failed.
+	Operation string
+	// AgentStderr contains captured stderr from the ACP agent process.
+	AgentStderr string
+
+	// Command describes the ACP-compatible process to launch.
+	Command struct {
+		Name CommandName
+		Args []CommandArgument
+	}
+
+	// Options configures one bounded ACP prompt run.
+	Options struct {
+		Command         Command
+		WorkDir         types.FilesystemPath //goplint:ignore -- ACP session cwd is required by options validation.
+		Policies        Policies
+		ShutdownTimeout time.Duration
+		Stderr          io.Writer //goplint:ignore -- optional adapter stream mirrors os/exec stderr plumbing.
+	}
+
+	// Prompt is the bounded user turn sent to the ACP agent.
+	Prompt struct {
+		Text PromptText
+	}
+
+	// Result is the normalized result of one ACP prompt turn.
+	Result struct {
+		SessionID  SessionID
+		StopReason StopReason
+		Events     []Event
+	}
+
+	// Event is a normalized ACP streamed update.
+	Event struct {
+		Kind       EventKind
+		Text       EventText
+		ToolCallID ToolCallID
+		ToolTitle  ToolTitle
+		ToolKind   ToolKind
+		ToolStatus ToolStatus
+	}
+
+	// ToolCall is the normalized tool-call detail for permission requests.
+	ToolCall struct {
+		ID        ToolCallID
+		Title     ToolTitle
+		Kind      ToolKind
+		Status    ToolStatus
+		Locations []types.FilesystemPath
+	}
+
+	// PermissionOption is one policy choice offered by an ACP agent.
+	PermissionOption struct {
+		ID   PermissionOptionID
+		Kind PermissionOptionKind
+		Name PermissionOptionName
+	}
+
+	// PermissionOutcome is the selected or cancelled result returned by policy.
+	PermissionOutcome struct {
+		Kind             PermissionOutcomeKind
+		SelectedOptionID PermissionOptionID
+	}
+
+	// PermissionRequest is the Invowk-owned permission callback request.
+	PermissionRequest struct {
+		SessionID SessionID
+		ToolCall  ToolCall
+		Options   []PermissionOption
+	}
+
+	// PermissionResponse is the Invowk-owned permission callback response.
+	PermissionResponse struct {
+		Outcome PermissionOutcome
+	}
+
+	// ReadTextFileRequest is a mediated ACP filesystem read request.
+	ReadTextFileRequest struct {
+		SessionID SessionID
+		Path      types.FilesystemPath //goplint:ignore -- ACP read path is required by protocol validation.
+		Line      *LineNumber
+		Limit     *LineLimit
+	}
+
+	// ReadTextFileResponse is a mediated ACP filesystem read response.
+	ReadTextFileResponse struct {
+		Content FileContent
+	}
+
+	// WriteTextFileRequest is a mediated ACP filesystem write request.
+	WriteTextFileRequest struct {
+		SessionID SessionID
+		Path      types.FilesystemPath //goplint:ignore -- ACP write path is required by protocol validation.
+		Content   FileContent
+	}
+
+	// WriteTextFileResponse is a mediated ACP filesystem write response.
+	WriteTextFileResponse struct{}
+
+	// TerminalEnv is one environment variable requested for an ACP terminal.
+	TerminalEnv struct {
+		Name  TerminalEnvName
+		Value TerminalEnvValue
+	}
+
+	// CreateTerminalRequest is a mediated ACP terminal creation request.
+	CreateTerminalRequest struct {
+		SessionID       SessionID
+		Command         TerminalCommand
+		Args            []TerminalArgument
+		WorkDir         *types.FilesystemPath
+		Env             []TerminalEnv
+		OutputByteLimit *TerminalOutputLimit
+	}
+
+	// CreateTerminalResponse is a mediated ACP terminal creation response.
+	CreateTerminalResponse struct {
+		TerminalID TerminalID
+	}
+
+	// TerminalOutputRequest is a mediated ACP terminal output request.
+	TerminalOutputRequest struct {
+		SessionID  SessionID
+		TerminalID TerminalID
+	}
+
+	// TerminalOutputResponse is a mediated ACP terminal output response.
+	TerminalOutputResponse struct {
+		Output    TerminalOutput
+		Truncated TerminalOutputTruncated
+	}
+
+	// ReleaseTerminalRequest is a mediated ACP terminal release request.
+	ReleaseTerminalRequest struct {
+		SessionID  SessionID
+		TerminalID TerminalID
+	}
+
+	// ReleaseTerminalResponse is a mediated ACP terminal release response.
+	ReleaseTerminalResponse struct{}
+
+	// WaitForTerminalExitRequest is a mediated ACP terminal wait request.
+	WaitForTerminalExitRequest struct {
+		SessionID  SessionID
+		TerminalID TerminalID
+	}
+
+	// WaitForTerminalExitResponse is a mediated ACP terminal wait response.
+	WaitForTerminalExitResponse struct {
+		ExitCode *types.ExitCode
+		Signal   TerminalSignal
+	}
+
+	// KillTerminalRequest is a mediated ACP terminal kill request.
+	KillTerminalRequest struct {
+		SessionID  SessionID
+		TerminalID TerminalID
+	}
+
+	// KillTerminalResponse is a mediated ACP terminal kill response.
+	KillTerminalResponse struct{}
+
+	// OperationError wraps an ACP lifecycle, protocol, or process failure.
+	OperationError struct {
+		Operation Operation
+		Kind      error
+		Err       error
+		Stderr    AgentStderr
+	}
+
+	// InvalidOptionsError is returned when ACP options or prompt fields are invalid.
+	InvalidOptionsError struct {
+		FieldErrors []error
+	}
+)
+
+// SelectedPermissionOutcome returns a permission outcome selecting optionID.
+func SelectedPermissionOutcome(optionID PermissionOptionID) PermissionOutcome {
+	return PermissionOutcome{
+		Kind:             PermissionOutcomeKindSelected,
+		SelectedOptionID: optionID,
+	}
+}
+
+// CancelledPermissionOutcome returns a cancelled permission outcome.
+func CancelledPermissionOutcome() PermissionOutcome {
+	return PermissionOutcome{Kind: PermissionOutcomeKindCancelled}
+}
+
+// String returns the command name as text.
+func (n CommandName) String() string { return string(n) }
+
+// Validate returns an error if the command name is empty.
+func (n CommandName) Validate() error {
+	if strings.TrimSpace(string(n)) == "" {
+		return fmt.Errorf("%w: command name must be non-empty", ErrInvalidOptions)
+	}
+	return nil
+}
+
+// String returns the command argument as text.
+func (a CommandArgument) String() string { return string(a) }
+
+// String returns the prompt text.
+func (p PromptText) String() string { return string(p) }
+
+// Validate returns an error if the prompt text is empty.
+func (p PromptText) Validate() error {
+	if strings.TrimSpace(string(p)) == "" {
+		return fmt.Errorf("%w: prompt text must be non-empty", ErrInvalidOptions)
+	}
+	return nil
+}
+
+// String returns the session ID.
+func (id SessionID) String() string { return string(id) }
+
+// String returns the stop reason.
+func (r StopReason) String() string { return string(r) }
+
+// String returns the event kind.
+func (k EventKind) String() string { return string(k) }
+
+// String returns the event text.
+func (t EventText) String() string { return string(t) }
+
+// String returns the tool-call ID.
+func (id ToolCallID) String() string { return string(id) }
+
+// String returns the tool title.
+func (t ToolTitle) String() string { return string(t) }
+
+// String returns the tool kind.
+func (k ToolKind) String() string { return string(k) }
+
+// String returns the tool status.
+func (s ToolStatus) String() string { return string(s) }
+
+// String returns the permission option ID.
+func (id PermissionOptionID) String() string { return string(id) }
+
+// Validate returns an error if the permission option ID is empty.
+func (id PermissionOptionID) Validate() error {
+	if strings.TrimSpace(string(id)) == "" {
+		return fmt.Errorf("%w: permission option id must be non-empty", ErrInvalidOptions)
+	}
+	return nil
+}
+
+// String returns the permission option kind.
+func (k PermissionOptionKind) String() string { return string(k) }
+
+// String returns the permission option name.
+func (n PermissionOptionName) String() string { return string(n) }
+
+// String returns the permission outcome kind.
+func (k PermissionOutcomeKind) String() string { return string(k) }
+
+// Validate returns an error if the permission outcome is invalid.
+func (o PermissionOutcome) Validate() error {
+	switch o.Kind {
+	case PermissionOutcomeKindSelected:
+		return o.SelectedOptionID.Validate()
+	case PermissionOutcomeKindCancelled:
+		return nil
+	default:
+		return fmt.Errorf("%w: unknown permission outcome %q", ErrInvalidOptions, o.Kind)
+	}
+}
+
+// String returns the file content.
+func (c FileContent) String() string { return string(c) }
+
+// Validate returns an error if the line number is invalid.
+func (n LineNumber) Validate() error {
+	if n < 1 {
+		return fmt.Errorf("%w: line number must be positive", ErrInvalidOptions)
+	}
+	return nil
+}
+
+// Validate returns an error if the line limit is invalid.
+func (l LineLimit) Validate() error {
+	if l < 1 {
+		return fmt.Errorf("%w: line limit must be positive", ErrInvalidOptions)
+	}
+	return nil
+}
+
+// String returns the terminal command.
+func (c TerminalCommand) String() string { return string(c) }
+
+// String returns the terminal argument.
+func (a TerminalArgument) String() string { return string(a) }
+
+// String returns the terminal environment variable name.
+func (n TerminalEnvName) String() string { return string(n) }
+
+// String returns the terminal environment variable value.
+func (v TerminalEnvValue) String() string { return string(v) }
+
+// String returns the terminal ID.
+func (id TerminalID) String() string { return string(id) }
+
+// String returns the terminal output.
+func (o TerminalOutput) String() string { return string(o) }
+
+// String returns the terminal signal.
+func (s TerminalSignal) String() string { return string(s) }
+
+// String returns the operation name.
+func (o Operation) String() string { return string(o) }
+
+// String returns captured agent stderr.
+func (s AgentStderr) String() string { return string(s) }
+
+// Validate returns an error if the command is invalid.
+func (c Command) Validate() error {
+	return c.Name.Validate()
+}
+
+// ArgsAsStrings returns raw argv strings for os/exec.
+//
+//goplint:ignore -- os/exec requires raw argv strings at the process adapter boundary.
+func (c Command) ArgsAsStrings() []string {
+	args := make([]string, 0, len(c.Args))
+	for _, arg := range c.Args {
+		args = append(args, arg.String())
+	}
+	return args
+}
+
+// Validate returns an error if options are invalid.
+func (o Options) Validate() error {
+	var fieldErrors []error
+	if err := o.Command.Validate(); err != nil {
+		fieldErrors = append(fieldErrors, fmt.Errorf("command: %w", err))
+	}
+	if err := o.WorkDir.Validate(); err != nil {
+		fieldErrors = append(fieldErrors, fmt.Errorf("workdir: %w", err))
+	}
+	if len(fieldErrors) > 0 {
+		return &InvalidOptionsError{FieldErrors: fieldErrors}
+	}
+	return nil
+}
+
+// Validate returns an error if the prompt is invalid.
+func (p Prompt) Validate() error {
+	if err := p.Text.Validate(); err != nil {
+		return &InvalidOptionsError{FieldErrors: []error{fmt.Errorf("prompt: %w", err)}}
+	}
+	return nil
+}
+
+// ShutdownDuration returns the configured process shutdown timeout.
+func (o Options) ShutdownDuration() time.Duration {
+	if o.ShutdownTimeout <= 0 {
+		return defaultShutdownTimeout
+	}
+	return o.ShutdownTimeout
+}
+
+// Error implements error.
+func (e *OperationError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	msg := fmt.Sprintf("%s: %v", e.Operation, e.Err)
+	if e.Stderr != "" {
+		msg += fmt.Sprintf(" (agent stderr: %s)", e.Stderr)
+	}
+	return msg
+}
+
+// Unwrap returns the sentinel and underlying cause for errors.Is compatibility.
+func (e *OperationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return errors.Join(e.Kind, e.Err)
+}
+
+// Error implements error.
+func (e *InvalidOptionsError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return types.FormatFieldErrors("ACP client options", e.FieldErrors)
+}
+
+// Unwrap returns ErrInvalidOptions plus field errors for errors.Is compatibility.
+func (e *InvalidOptionsError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return errors.Join(append([]error{ErrInvalidOptions}, e.FieldErrors...)...)
+}

--- a/openspec/changes/add-acp-foundation/.openspec.yaml
+++ b/openspec/changes/add-acp-foundation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/add-acp-foundation/design.md
+++ b/openspec/changes/add-acp-foundation/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Invowk currently has LLM-aware workflows that are intentionally batch-shaped:
+
+- `invowk audit --llm` asks a model to analyze bounded audit context and turns responses into findings.
+- `invowk agent cmd create` asks a model for one validated CUE command object and may patch `invowkfile.cue`.
+- `internal/auditllm` supports OpenAI-compatible HTTP APIs, local Ollama-style servers, and CLI fallback through Claude Code, Codex CLI, and Gemini CLI.
+
+Those paths are good fits for one-shot completion, model preflight checks, structured output, validation feedback, and audit concurrency. ACP solves a different problem: long-lived agent sessions with protocol negotiation, streaming updates, permission prompts, file mediation, terminal mediation, and editor-like agent interoperability.
+
+This change adds only the ACP foundation. It does not route any existing command through ACP and does not expose ACP configuration to users yet.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a small internal ACP client-side foundation using `github.com/coder/acp-go-sdk`.
+- Isolate ACP-specific types and lifecycle handling behind an Invowk-owned package boundary.
+- Support fake-agent tests for initialize, session creation, prompt dispatch, streamed updates, cancellation, and policy callbacks.
+- Provide explicit policy interfaces for permission, filesystem, and terminal callbacks so future features can choose their safety model deliberately.
+- Keep existing LLM workflows behaviorally unchanged.
+
+**Non-Goals:**
+
+- Do not replace `internal/auditllm` or the direct OpenAI-compatible API path.
+- Do not move `invowk audit --llm` or `invowk agent cmd create` to ACP.
+- Do not auto-detect ACP adapters for Claude Code, Codex, Gemini, or any other tool.
+- Do not add user-facing CLI flags, config schema fields, CUE schema fields, generated docs, or website snippets.
+- Do not implement an Invowk ACP agent server.
+
+## Decisions
+
+### Decision: Add an internal ACP client package, not a user-facing provider
+
+Introduce an internal package such as `internal/acpclient` that owns ACP process/session orchestration. Future user-facing features can depend on this package, but no current command will call it.
+
+Alternatives considered:
+
+- Add `acp` as a new `llm.provider` value. Rejected because it would imply current one-shot workflows should use ACP immediately and would require user-facing configuration semantics before there is a feature consuming sessions.
+- Replace the CLI fallback completer with ACP. Rejected because current CLI fallback is a batch completion adapter, while ACP is a stateful session protocol.
+
+### Decision: Use `github.com/coder/acp-go-sdk`
+
+Use `coder/acp-go-sdk` as the ACP dependency. It provides tagged releases, generated protocol types, client and agent APIs, stdio examples, and examples for Claude Code and Gemini-style ACP integration.
+
+Alternatives considered:
+
+- Use `github.com/ironpark/go-acp`. Rejected for this foundation because it has no semver tags surfaced through the Go module/version checks used during research, lower adoption, and a less stable dependency story despite useful ergonomics.
+- Hand-roll ACP JSON-RPC. Rejected because ACP is still evolving and generated protocol types plus conformance-shaped tests reduce drift risk.
+
+### Decision: Keep ACP SDK types at the adapter edge
+
+The ACP package should translate SDK notifications, prompt responses, permissions, and file requests into Invowk-owned internal types or interfaces at its boundary. Other application packages should not need to import `github.com/coder/acp-go-sdk` unless they are deliberately joining the ACP adapter layer.
+
+Alternatives considered:
+
+- Let future features use `acp-go-sdk` directly. Rejected because it would spread protocol churn and make it harder to enforce Invowk policy boundaries.
+
+### Decision: Policy callbacks are explicit and restrictive
+
+ACP agents can request filesystem writes, terminal operations, and permissions. The foundation should require a caller-supplied policy object for these callbacks. The default test/noop policy should deny writes, decline permissions, and report unsupported terminal operations unless a future feature provides a stronger policy.
+
+Alternatives considered:
+
+- Auto-approve permissions for ease of testing. Rejected because it would create dangerous precedent for future agent features.
+- Let the ACP agent read/write the host filesystem directly. Rejected because Invowk should mediate these operations with the same care it applies elsewhere.
+
+### Decision: Tests use fake ACP peers only
+
+Add tests that start an in-process or test-binary ACP peer over stdio/pipes. Tests must not require real Claude Code, Codex, Gemini, network access, OAuth state, or API keys.
+
+Alternatives considered:
+
+- Smoke-test real external ACP adapters. Rejected for CI determinism and because adapter compatibility belongs in future integration tests once there is a user-facing feature.
+
+## Risks / Trade-offs
+
+- [Risk] A dormant package can rot before the first feature uses it. -> Mitigation: include fake-peer lifecycle tests and keep the package small enough that follow-up features can reshape it.
+- [Risk] ACP protocol churn can break the foundation. -> Mitigation: pin the SDK version and keep SDK types isolated in one internal package.
+- [Risk] Users may expect ACP support immediately once the dependency lands. -> Mitigation: avoid CLI/config/docs claims until a user-facing feature is proposed.
+- [Risk] The foundation could duplicate current LLM completion abstractions. -> Mitigation: keep one-shot completion untouched and name the ACP layer around sessions, not completions.
+- [Risk] Permission and filesystem callbacks can become a security boundary by accident. -> Mitigation: default restrictive behavior and require future features to define policy explicitly.
+
+## Migration Plan
+
+This change has no runtime migration. It adds an internal package and dependency only.
+
+Rollback is a normal code revert: remove the package, tests, and module dependency. Since no command uses the foundation, rollback should not affect user workflows.
+
+## Open Questions
+
+- Should the eventual user-facing feature be an interactive `invowk agent session` command, a TUI integration, or a backend for richer `agent cmd` authoring?
+- Should future ACP-backed features support only explicit adapter commands, or should Invowk eventually auto-detect known ACP adapters?
+- What is the first real permission policy: read-only analysis, write-with-confirmation, or feature-specific allowlists?

--- a/openspec/changes/add-acp-foundation/proposal.md
+++ b/openspec/changes/add-acp-foundation/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Invowk's current LLM integration is efficient for one-shot completion workflows, but it does not provide a protocol-level foundation for future stateful agent sessions, streamed updates, permission mediation, or editor-like agent interoperability. ACP is emerging as the right boundary for those interactive agent workflows, so Invowk should establish a small, unused internal foundation now before adding user-facing agent features on top of it.
+
+## What Changes
+
+- Add an internal ACP foundation for future stateful agent-session integrations using `github.com/coder/acp-go-sdk`.
+- Define a narrow internal boundary for launching ACP-compatible agent processes, negotiating protocol capabilities, creating sessions, sending prompts, handling streamed updates, and routing permission/file/terminal callbacks through Invowk-owned policy hooks.
+- Keep the foundation dormant: no existing command, config key, provider selection, `invowk audit --llm`, or `invowk agent cmd create` flow will use ACP in this change.
+- Preserve the current direct OpenAI-compatible API and CLI completion paths for existing one-shot LLM workflows.
+- Add focused tests and documentation comments that make the dormant foundation explicit and prevent accidental user-visible behavior changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-client-protocol-foundation`: Internal ACP substrate for future stateful agent-session features, including process lifecycle, protocol handshake, session creation, prompt dispatch, update collection, and policy callback boundaries.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Adds a new Go module dependency on `github.com/coder/acp-go-sdk`.
+- Adds internal packages for ACP session/process orchestration and callback policy boundaries.
+- Adds unit tests with fake ACP agents and no dependency on real Claude Code, Codex, Gemini, or networked model providers.
+- Does not change current user-facing CLI behavior, config schema, CUE schema, docs snippets, generated references, or existing LLM provider semantics.

--- a/openspec/changes/add-acp-foundation/specs/agent-client-protocol-foundation/spec.md
+++ b/openspec/changes/add-acp-foundation/specs/agent-client-protocol-foundation/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Dormant ACP foundation
+
+Invowk SHALL provide an internal ACP foundation for future stateful agent-session features without changing any current user-facing behavior.
+
+#### Scenario: Existing LLM workflows do not use ACP
+
+- **WHEN** a user runs `invowk audit --llm`, `invowk audit --llm-provider`, or `invowk agent cmd create`
+- **THEN** Invowk SHALL continue using the existing direct LLM provider and completion paths
+- **THEN** Invowk SHALL NOT route those workflows through the ACP foundation
+
+#### Scenario: No user-facing ACP configuration is introduced
+
+- **WHEN** this change is implemented
+- **THEN** Invowk SHALL NOT add ACP CLI flags, config schema fields, CUE schema fields, generated reference entries, or website snippets
+- **THEN** existing provider values such as `auto`, `claude`, `codex`, `gemini`, and `ollama` SHALL keep their current semantics
+
+### Requirement: ACP client substrate
+
+Invowk SHALL expose an internal client-side ACP substrate that can launch or connect to an explicitly supplied ACP-compatible agent process and drive a bounded agent turn.
+
+#### Scenario: ACP session lifecycle succeeds with a fake agent
+
+- **WHEN** a test fake ACP agent accepts initialization, creates a session, streams an update, and completes a prompt turn
+- **THEN** the ACP foundation SHALL perform protocol initialization, create the session, send the prompt, collect the streamed update, and return the final stop reason to the caller
+
+#### Scenario: ACP session cancellation is forwarded
+
+- **WHEN** the caller cancels an in-flight ACP prompt context
+- **THEN** the ACP foundation SHALL send an ACP cancellation notification for the active session when a session exists
+- **THEN** the prompt call SHALL return a cancellation error without leaking the agent process
+
+#### Scenario: Agent process lifecycle is owned by the foundation
+
+- **WHEN** an ACP agent process exits, fails to initialize, or the caller closes the session
+- **THEN** the ACP foundation SHALL close the connection, reap the process, and return an actionable error when startup or protocol negotiation failed
+
+### Requirement: ACP policy callbacks
+
+Invowk SHALL mediate ACP agent callbacks through explicit internal policy interfaces rather than allowing the ACP peer to access host resources implicitly.
+
+#### Scenario: Permission request is delegated to policy
+
+- **WHEN** an ACP agent requests permission for a tool call
+- **THEN** the ACP foundation SHALL delegate the request to the configured Invowk policy
+- **THEN** the selected permission outcome SHALL be sent back to the ACP agent
+
+#### Scenario: Filesystem callback is delegated to policy
+
+- **WHEN** an ACP agent requests a text-file read or write
+- **THEN** the ACP foundation SHALL delegate the operation to the configured Invowk filesystem policy
+- **THEN** the foundation SHALL NOT perform direct filesystem access unless the configured policy performs it
+
+#### Scenario: Unsupported terminal callback is explicit
+
+- **WHEN** an ACP agent requests terminal functionality and the configured policy does not support terminals
+- **THEN** the ACP foundation SHALL return an unsupported-operation error to the ACP agent
+
+### Requirement: Dependency isolation and deterministic tests
+
+Invowk SHALL keep the ACP SDK isolated to the internal ACP foundation and verify the foundation without real external agent tools.
+
+#### Scenario: ACP SDK imports are localized
+
+- **WHEN** the ACP foundation is implemented
+- **THEN** imports of `github.com/coder/acp-go-sdk` SHALL be limited to the internal ACP foundation package and its tests unless a later OpenSpec change explicitly expands the integration surface
+
+#### Scenario: Tests avoid real agent CLIs
+
+- **WHEN** the ACP foundation tests run
+- **THEN** they SHALL use fake ACP peers or test binaries
+- **THEN** they SHALL NOT require Claude Code, Codex, Gemini, OAuth state, API keys, network access, or installed external ACP adapters

--- a/openspec/changes/add-acp-foundation/tasks.md
+++ b/openspec/changes/add-acp-foundation/tasks.md
@@ -1,0 +1,37 @@
+## 1. Dependency and Package Foundation
+
+- [x] 1.1 Add pinned `github.com/coder/acp-go-sdk` dependency to `go.mod` and `go.sum`.
+- [x] 1.2 Create an internal ACP foundation package, such as `internal/acpclient`, with package documentation that states it is dormant and not wired to current CLI flows.
+- [x] 1.3 Define Invowk-owned request, response, event, lifecycle, and policy types so callers outside the ACP foundation do not need to import ACP SDK types.
+
+## 2. ACP Session Lifecycle
+
+- [x] 2.1 Implement explicit ACP process/session startup from caller-supplied argv and working directory.
+- [x] 2.2 Implement ACP initialization and capability negotiation through the SDK client-side connection.
+- [x] 2.3 Implement session creation, prompt dispatch, streamed update collection, final stop-reason return, and graceful close.
+- [x] 2.4 Implement prompt cancellation forwarding and process cleanup for canceled or failed sessions.
+- [x] 2.5 Normalize ACP startup, negotiation, prompt, cancellation, and process-exit failures into actionable internal errors.
+
+## 3. Policy Callback Boundary
+
+- [x] 3.1 Define explicit permission, filesystem, and terminal policy interfaces for ACP callbacks.
+- [x] 3.2 Route ACP permission requests through the configured permission policy and return selected outcomes to the agent.
+- [x] 3.3 Route ACP text-file read/write requests through the configured filesystem policy without direct filesystem access in the foundation.
+- [x] 3.4 Return explicit unsupported-operation errors for terminal callbacks when no terminal policy is configured.
+- [x] 3.5 Provide a restrictive noop policy for tests and future callers that need deny-by-default behavior.
+
+## 4. Dormancy and Isolation Guarantees
+
+- [x] 4.1 Verify no existing command path, including `invowk audit --llm` and `invowk agent cmd create`, imports or calls the ACP foundation.
+- [x] 4.2 Verify no CLI flags, config schema fields, CUE schema fields, generated references, website snippets, or README user-facing ACP claims are added by this change.
+- [x] 4.3 Add an import-boundary check or focused test that fails if `github.com/coder/acp-go-sdk` is imported outside the ACP foundation package and its tests.
+
+## 5. Tests and Verification
+
+- [x] 5.1 Add fake ACP peer tests for initialize, session creation, prompt dispatch, streamed update collection, and final stop reason.
+- [x] 5.2 Add fake ACP peer tests for cancellation forwarding and process cleanup.
+- [x] 5.3 Add policy callback tests for permission delegation, filesystem delegation, and unsupported terminal behavior.
+- [x] 5.4 Run targeted ACP foundation tests.
+- [x] 5.5 Run `go test ./internal/acpclient ./internal/auditllm ./internal/agentcmd ./cmd/invowk`.
+- [x] 5.6 Run `make check-baseline`.
+- [x] 5.7 Run `openspec validate add-acp-foundation --strict`.

--- a/tools/goplint/exceptions.toml
+++ b/tools/goplint/exceptions.toml
@@ -100,6 +100,30 @@ reason = "full paths like /bin/bash; BinaryName rejects paths"
 pattern = "ResolveDockerfilePath.*"
 reason = "exec boundary — params/return passed to filepath operations"
 
+[[exceptions]]
+pattern = "acpclient.*.Validate"
+reason = "ACP foundation adapter mirrors generated protocol/process labels; invariants are enforced at SDK callback and RunPrompt boundaries"
+
+[[exceptions]]
+pattern = "acpclient.*.String"
+reason = "ACP foundation adapter value types are protocol labels where zero/empty values can be meaningful display or optional fields"
+
+[[exceptions]]
+pattern = "acpclient.*.constructor"
+reason = "ACP foundation adapter DTOs are internal protocol translation records, not domain aggregates"
+
+[[exceptions]]
+pattern = "acpclient.*.struct-validate-fields"
+reason = "ACP foundation adapter DTOs expose mediated protocol callback payloads; callback methods validate generated ACP inputs before translation"
+
+[[exceptions]]
+pattern = "acpclient.PermissionOutcome.SelectedOptionID.validate-delegation"
+reason = "SelectedOptionID is conditionally required only when the ACP permission outcome kind is selected"
+
+[[exceptions]]
+pattern = "acpclient.filesystemPathFromACP.path"
+reason = "ACP generated protocol supplies raw path text, converted to FilesystemPath and validated immediately"
+
 # =============================================================================
 # Virtual Runtime Adapter Boundaries
 # =============================================================================


### PR DESCRIPTION
## Summary

- add a dormant internal ACP client foundation using `github.com/coder/acp-go-sdk`
- isolate SDK protocol details behind Invowk-owned request/result/event/policy types
- add restrictive permission, filesystem, and terminal policy callbacks plus fake-peer lifecycle tests
- include the OpenSpec proposal/design/spec/tasks for the foundational ACP work

## Verification

- `go test ./internal/acpclient`
- `go test ./internal/acpclient ./internal/auditllm ./internal/agentcmd ./cmd/invowk`
- `make tidy`
- `make lint`
- `make check-baseline`
- `make test`
- `openspec validate add-acp-foundation --strict`
- `git diff --check`

Notes: local container-engine integration cases skipped because no Docker/Podman engine is available on this host. Local `sonar-local` passed with 0 unresolved issues, but reported no branch analysis until PR/remote analysis is available.